### PR TITLE
Implement followup for ext/uri

### DIFF
--- a/ext/lexbor/lexbor/url/url.c
+++ b/ext/lexbor/lexbor/url/url.c
@@ -26,21 +26,6 @@
 #define LXB_URL_BUFFER_SIZE 4096
 #define LXB_URL_BUFFER_NUM_SIZE 128
 
-
-typedef enum {
-    LXB_URL_MAP_UNDEF         = 0x00,
-    LXB_URL_MAP_C0            = 0x01,
-    LXB_URL_MAP_FRAGMENT      = 0x02,
-    LXB_URL_MAP_QUERY         = 0x04,
-    LXB_URL_MAP_SPECIAL_QUERY = 0x08,
-    LXB_URL_MAP_PATH          = 0x10,
-    LXB_URL_MAP_USERINFO      = 0x20,
-    LXB_URL_MAP_COMPONENT     = 0x40,
-    LXB_URL_MAP_X_WWW_FORM    = 0x80,
-    LXB_URL_MAP_ALL           = 0xff
-}
-lxb_url_map_type_t;
-
 typedef enum {
     LXB_URL_HOST_OPT_UNDEF       = 0 << 0,
     LXB_URL_HOST_OPT_NOT_SPECIAL = 1 << 0,
@@ -568,13 +553,6 @@ lxb_url_percent_encode_after_encoding(const lxb_char_t *data,
                                       bool space_as_plus);
 
 static lxb_status_t
-lxb_url_percent_encode_after_utf_8(const lxb_char_t *data,
-                                   const lxb_char_t *end, lexbor_str_t *str,
-                                   lexbor_mraw_t *mraw,
-                                   lxb_url_map_type_t enmap,
-                                   bool space_as_plus);
-
-static lxb_status_t
 lxb_url_host_parse(lxb_url_parser_t *parser, const lxb_char_t *data,
                    const lxb_char_t *end, lxb_url_host_t *host,
                    lexbor_mraw_t *mraw, lxb_url_host_opt_t opt);
@@ -858,12 +836,6 @@ lxb_url_is_url_codepoint(lxb_codepoint_t cp)
     }
 
     return lxb_url_codepoint_alphanumeric[(lxb_char_t) cp] != 0xFF;
-}
-
-lxb_inline bool
-lxb_url_is_special(const lxb_url_t *url)
-{
-    return url->scheme.type != LXB_URL_SCHEMEL_TYPE__UNKNOWN;
 }
 
 lxb_inline const lxb_url_scheme_data_t *
@@ -3259,7 +3231,7 @@ lxb_url_percent_encode_after_encoding(const lxb_char_t *data,
     return LXB_STATUS_OK;
 }
 
-static lxb_status_t
+lxb_status_t
 lxb_url_percent_encode_after_utf_8(const lxb_char_t *data,
                                    const lxb_char_t *end, lexbor_str_t *str,
                                    lexbor_mraw_t *mraw,

--- a/ext/lexbor/lexbor/url/url.h
+++ b/ext/lexbor/lexbor/url/url.h
@@ -193,10 +193,32 @@ typedef struct {
 }
 lxb_url_search_params_t;
 
+typedef enum {
+	LXB_URL_MAP_UNDEF         = 0x00,
+	LXB_URL_MAP_C0            = 0x01,
+	LXB_URL_MAP_FRAGMENT      = 0x02,
+	LXB_URL_MAP_QUERY         = 0x04,
+	LXB_URL_MAP_SPECIAL_QUERY = 0x08,
+	LXB_URL_MAP_PATH          = 0x10,
+	LXB_URL_MAP_USERINFO      = 0x20,
+	LXB_URL_MAP_COMPONENT     = 0x40,
+	LXB_URL_MAP_X_WWW_FORM    = 0x80,
+	LXB_URL_MAP_ALL           = 0xff
+}
+lxb_url_map_type_t;
+
+
 typedef lexbor_action_t
 (*lxb_url_search_params_match_f)(lxb_url_search_params_t *sp,
                                  lxb_url_search_entry_t *entry, void *ctx);
 
+
+LXB_API lxb_status_t
+lxb_url_percent_encode_after_utf_8(const lxb_char_t *data,
+								   const lxb_char_t *end, lexbor_str_t *str,
+								   lexbor_mraw_t *mraw,
+								   lxb_url_map_type_t enmap,
+								   bool space_as_plus);
 
 /*
  * Create lxb_url_parser_t object.
@@ -771,6 +793,12 @@ lxb_inline const lexbor_str_t *
 lxb_url_scheme(const lxb_url_t *url)
 {
     return &url->scheme.name;
+}
+
+lxb_inline bool
+lxb_url_is_special(const lxb_url_t *url)
+{
+	return url->scheme.type != LXB_URL_SCHEMEL_TYPE__UNKNOWN;
 }
 
 lxb_inline const lexbor_str_t *

--- a/ext/uri/config.m4
+++ b/ext/uri/config.m4
@@ -11,6 +11,8 @@ PHP_ARG_WITH([external-uriparser],
 PHP_INSTALL_HEADERS([ext/uri], m4_normalize([
   php_uri.h
   php_uri_common.h
+  php_uri_parser.h
+  php_uri_query.h
   uri_parser_rfc3986.h
   uri_parser_whatwg.h
   uri_parser_php_parse_url.h
@@ -38,7 +40,7 @@ else
   PHP_EVAL_INCLINE([$LIBURIPARSER_CFLAGS])
 fi
 
-PHP_NEW_EXTENSION(uri, [php_uri.c php_uri_common.c uri_parser_rfc3986.c uri_parser_whatwg.c uri_parser_php_parse_url.c $URIPARSER_SOURCES], [no],,[$URI_CFLAGS -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
+PHP_NEW_EXTENSION(uri, [php_uri.c php_uri_common.c php_uri_parser.c php_uri_query.c uri_parser_rfc3986.c uri_parser_whatwg.c uri_parser_php_parse_url.c $URIPARSER_SOURCES], [no],,[$URI_CFLAGS -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1])
 PHP_ADD_EXTENSION_DEP(uri, lexbor)
 
 if test "$PHP_EXTERNAL_URIPARSER" = "no"; then

--- a/ext/uri/php_uri.c
+++ b/ext/uri/php_uri.c
@@ -26,78 +26,79 @@
 #include "ext/standard/info.h"
 
 #include "php_uri.h"
+#include "php_uri_query.h"
 #include "uri_parser_whatwg.h"
 #include "uri_parser_rfc3986.h"
 #include "uri_parser_php_parse_url.h"
 #include "php_uri_arginfo.h"
 #include "uriparser/Uri.h"
 
-zend_class_entry *php_uri_ce_rfc3986_uri;
-zend_class_entry *php_uri_ce_whatwg_url;
-zend_class_entry *php_uri_ce_comparison_mode;
-zend_class_entry *php_uri_ce_exception;
-zend_class_entry *php_uri_ce_error;
-zend_class_entry *php_uri_ce_invalid_uri_exception;
-zend_class_entry *php_uri_ce_whatwg_invalid_url_exception;
-zend_class_entry *php_uri_ce_whatwg_url_validation_error_type;
-zend_class_entry *php_uri_ce_whatwg_url_validation_error;
-
 static zend_object_handlers object_handlers_rfc3986_uri;
+static zend_object_handlers object_handlers_rfc3986_uri_query_params;
 static zend_object_handlers object_handlers_whatwg_uri;
+static zend_object_handlers object_handlers_whatwg_url_query_params;
 
 static const zend_module_dep uri_deps[] = {
 	ZEND_MOD_REQUIRED("lexbor")
 	ZEND_MOD_END
 };
 
-static zend_array uri_parsers;
 
-static HashTable *uri_get_debug_properties(php_uri_object *object)
+PHPAPI zend_result php_uri_parser_register(const php_uri_parser *uri_parser)
 {
-	const HashTable *std_properties = zend_std_get_properties(&object->std);
-	HashTable *result = zend_array_dup(std_properties);
+	zend_string *key = zend_string_init_interned(uri_parser->name, strlen(uri_parser->name), true);
 
-	const php_uri_parser * const parser = object->parser;
-	void * const uri = object->uri;
+	ZEND_ASSERT(uri_parser->name != NULL);
+	ZEND_ASSERT(uri_parser->parse != NULL);
+	ZEND_ASSERT(uri_parser->clone != NULL || strcmp(uri_parser->name, PHP_URI_PARSER_PHP_PARSE_URL) == 0);
+	ZEND_ASSERT(uri_parser->to_string != NULL || strcmp(uri_parser->name, PHP_URI_PARSER_PHP_PARSE_URL) == 0);
+	ZEND_ASSERT(uri_parser->destroy != NULL);
 
-	if (UNEXPECTED(uri == NULL)) {
-		return result;
-	}
+	zend_result result = zend_hash_add_ptr(&uri_parsers, key, (void *) uri_parser) != NULL ? SUCCESS : FAILURE;
 
-	zval tmp;
-	if (parser->property_handler.scheme.read(uri, PHP_URI_COMPONENT_READ_MODE_RAW, &tmp) == SUCCESS) {
-		zend_hash_update(result, ZSTR_KNOWN(ZEND_STR_SCHEME), &tmp);
-	}
-
-	if (parser->property_handler.username.read(uri, PHP_URI_COMPONENT_READ_MODE_RAW, &tmp) == SUCCESS) {
-		zend_hash_update(result, ZSTR_KNOWN(ZEND_STR_USERNAME), &tmp);
-	}
-
-	if (parser->property_handler.password.read(uri, PHP_URI_COMPONENT_READ_MODE_RAW, &tmp) == SUCCESS) {
-		zend_hash_update(result, ZSTR_KNOWN(ZEND_STR_PASSWORD), &tmp);
-	}
-
-	if (parser->property_handler.host.read(uri, PHP_URI_COMPONENT_READ_MODE_RAW, &tmp) == SUCCESS) {
-		zend_hash_update(result, ZSTR_KNOWN(ZEND_STR_HOST), &tmp);
-	}
-
-	if (parser->property_handler.port.read(uri, PHP_URI_COMPONENT_READ_MODE_RAW, &tmp) == SUCCESS) {
-		zend_hash_update(result, ZSTR_KNOWN(ZEND_STR_PORT), &tmp);
-	}
-
-	if (parser->property_handler.path.read(uri, PHP_URI_COMPONENT_READ_MODE_RAW, &tmp) == SUCCESS) {
-		zend_hash_update(result, ZSTR_KNOWN(ZEND_STR_PATH), &tmp);
-	}
-
-	if (parser->property_handler.query.read(uri, PHP_URI_COMPONENT_READ_MODE_RAW, &tmp) == SUCCESS) {
-		zend_hash_update(result, ZSTR_KNOWN(ZEND_STR_QUERY), &tmp);
-	}
-
-	if (parser->property_handler.fragment.read(uri, PHP_URI_COMPONENT_READ_MODE_RAW, &tmp) == SUCCESS) {
-		zend_hash_update(result, ZSTR_KNOWN(ZEND_STR_FRAGMENT), &tmp);
-	}
+	zend_string_release_ex(key, true);
 
 	return result;
+}
+
+PHPAPI php_uri_object *php_uri_object_create(zend_class_entry *class_type, const php_uri_parser *parser)
+{
+	php_uri_object *uri_object = zend_object_alloc(sizeof(*uri_object), class_type);
+
+	zend_object_std_init(&uri_object->std, class_type);
+	object_properties_init(&uri_object->std, class_type);
+
+	uri_object->parser = parser;
+	uri_object->uri = NULL;
+
+	return uri_object;
+}
+
+PHPAPI void php_uri_object_handler_free(zend_object *object)
+{
+	php_uri_object *uri_object = php_uri_object_from_obj(object);
+
+	uri_object->parser->destroy(uri_object->uri);
+	zend_object_std_dtor(&uri_object->std);
+}
+
+PHPAPI zend_object *php_uri_object_handler_clone(zend_object *object)
+{
+	php_uri_object *uri_object = php_uri_object_from_obj(object);
+
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	php_uri_object *new_uri_object = php_uri_object_from_obj(object->ce->create_object(object->ce));
+	ZEND_ASSERT(new_uri_object->parser == uri_object->parser);
+
+	void *uri = uri_object->parser->clone(uri_object->uri);
+	ZEND_ASSERT(uri != NULL);
+
+	new_uri_object->uri = uri;
+
+	zend_objects_clone_members(&new_uri_object->std, &uri_object->std);
+
+	return &new_uri_object->std;
 }
 
 PHPAPI const php_uri_parser *php_uri_get_parser(zend_string *uri_parser_name)
@@ -286,740 +287,6 @@ ZEND_ATTRIBUTE_NONNULL PHPAPI void php_uri_struct_free(php_uri *uri)
 	efree(uri);
 }
 
-/**
- * Pass the errors parameter by ref to errors_zv for userland, and frees it if
- * it is not not needed anymore.
- */
-static zend_result pass_errors_by_ref_and_free(zval *errors_zv, zval *errors)
-{
-	ZEND_ASSERT(Z_TYPE_P(errors) == IS_UNDEF || Z_TYPE_P(errors) == IS_ARRAY);
-
-	/* There was no error during parsing */
-	if (Z_ISUNDEF_P(errors)) {
-		return SUCCESS;
-	}
-
-	/* The errors parameter is an array, but the pass-by ref argument stored by
-	 * errors_zv was not passed - the URI implementation either doesn't support
-	 * returning additional error information, or the caller is not interested in it */
-	if (errors_zv == NULL) {
-		zval_ptr_dtor(errors);
-		return SUCCESS;
-	}
-
-	ZEND_TRY_ASSIGN_REF_TMP(errors_zv, errors);
-	if (EG(exception)) {
-		return FAILURE;
-	}
-
-	return SUCCESS;
-}
-
-ZEND_ATTRIBUTE_NONNULL_ARGS(1, 2) PHPAPI void php_uri_instantiate_uri(
-		INTERNAL_FUNCTION_PARAMETERS, const zend_string *uri_str, const php_uri_object *base_url_object,
-		bool should_throw, bool should_update_this_object, zval *errors_zv
-) {
-
-	php_uri_object *uri_object;
-	if (should_update_this_object) {
-		uri_object = Z_URI_OBJECT_P(ZEND_THIS);
-		if (uri_object->uri != NULL) {
-			zend_throw_error(NULL, "Cannot modify readonly object of class %s", ZSTR_VAL(Z_OBJCE_P(ZEND_THIS)->name));
-			RETURN_THROWS();
-		}
-	} else {
-		if (EX(func)->common.fn_flags & ZEND_ACC_STATIC) {
-			object_init_ex(return_value, Z_CE_P(ZEND_THIS));
-		} else {
-			object_init_ex(return_value, Z_OBJCE_P(ZEND_THIS));
-		}
-		uri_object = Z_URI_OBJECT_P(return_value);
-	}
-
-	const php_uri_parser *uri_parser = uri_object->parser;
-
-	zval errors;
-	ZVAL_UNDEF(&errors);
-
-	void *base_url = NULL;
-	if (base_url_object != NULL) {
-		ZEND_ASSERT(base_url_object->std.ce == uri_object->std.ce);
-		ZEND_ASSERT(base_url_object->uri != NULL);
-		ZEND_ASSERT(base_url_object->parser == uri_parser);
-		base_url = base_url_object->uri;
-	}
-
-	void *uri = uri_parser->parse(ZSTR_VAL(uri_str), ZSTR_LEN(uri_str), base_url, errors_zv != NULL ? &errors : NULL, !should_throw);
-	if (UNEXPECTED(uri == NULL)) {
-		if (should_throw) {
-			zval_ptr_dtor(&errors);
-			RETURN_THROWS();
-		} else {
-			if (pass_errors_by_ref_and_free(errors_zv, &errors) == FAILURE) {
-				RETURN_THROWS();
-			}
-			zval_ptr_dtor(return_value);
-			RETURN_NULL();
-		}
-	}
-
-	if (pass_errors_by_ref_and_free(errors_zv, &errors) == FAILURE) {
-		uri_parser->destroy(uri);
-		RETURN_THROWS();
-	}
-
-	uri_object->uri = uri;
-}
-
-static void create_rfc3986_uri(INTERNAL_FUNCTION_PARAMETERS, bool is_constructor)
-{
-	zend_string *uri_str;
-	zend_object *base_url_object = NULL;
-
-	ZEND_PARSE_PARAMETERS_START(1, 2)
-		Z_PARAM_STR(uri_str)
-		Z_PARAM_OPTIONAL
-		Z_PARAM_OBJ_OF_CLASS_OR_NULL(base_url_object, php_uri_ce_rfc3986_uri)
-	ZEND_PARSE_PARAMETERS_END();
-
-	php_uri_instantiate_uri(INTERNAL_FUNCTION_PARAM_PASSTHRU,
-		uri_str, base_url_object ? php_uri_object_from_obj(base_url_object) : NULL, is_constructor, is_constructor, NULL);
-}
-
-static bool is_list_of_whatwg_validation_errors(const HashTable *array)
-{
-	if (!zend_array_is_list(array)) {
-		return false;
-	}
-
-	ZEND_HASH_FOREACH_VAL(array, zval *val) {
-		/* Do not allow references as they may change types after checking. */
-
-		if (Z_TYPE_P(val) != IS_OBJECT) {
-			return false;
-		}
-
-		if (!instanceof_function(Z_OBJCE_P(val), php_uri_ce_whatwg_url_validation_error)) {
-			return false;
-		}
-	} ZEND_HASH_FOREACH_END();
-
-	return true;
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, parse)
-{
-	create_rfc3986_uri(INTERNAL_FUNCTION_PARAM_PASSTHRU, false);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, __construct)
-{
-	create_rfc3986_uri(INTERNAL_FUNCTION_PARAM_PASSTHRU, true);
-}
-
-PHP_METHOD(Uri_WhatWg_InvalidUrlException, __construct)
-{
-	zend_string *message = NULL;
-	zval *errors = NULL;
-	zend_long code = 0;
-	zval *previous = NULL;
-
-	ZEND_PARSE_PARAMETERS_START(0, 4)
-		Z_PARAM_OPTIONAL
-		Z_PARAM_STR(message)
-		Z_PARAM_ARRAY(errors)
-		Z_PARAM_LONG(code)
-		Z_PARAM_OBJECT_OF_CLASS_OR_NULL(previous, zend_ce_throwable)
-	ZEND_PARSE_PARAMETERS_END();
-
-	if (zend_update_exception_properties(INTERNAL_FUNCTION_PARAM_PASSTHRU, message, code, previous) == FAILURE) {
-		RETURN_THROWS();
-	}
-
-	if (errors == NULL) {
-		zval tmp;
-		ZVAL_EMPTY_ARRAY(&tmp);
-		zend_update_property(php_uri_ce_whatwg_invalid_url_exception, Z_OBJ_P(ZEND_THIS), ZEND_STRL("errors"), &tmp);
-	} else {
-		if (!is_list_of_whatwg_validation_errors(Z_ARR_P(errors))) {
-			zend_argument_value_error(2, "must be a list of %s", ZSTR_VAL(php_uri_ce_whatwg_url_validation_error->name));
-			RETURN_THROWS();
-		}
-
-		zend_update_property(php_uri_ce_whatwg_invalid_url_exception, Z_OBJ_P(ZEND_THIS), ZEND_STRL("errors"), errors);
-	}
-	if (EG(exception)) {
-		RETURN_THROWS();
-	}
-}
-
-PHP_METHOD(Uri_WhatWg_UrlValidationError, __construct)
-{
-	zend_string *context;
-	zval *type;
-	bool failure;
-
-	ZEND_PARSE_PARAMETERS_START(3, 3)
-		Z_PARAM_STR(context)
-		Z_PARAM_OBJECT_OF_CLASS(type, php_uri_ce_whatwg_url_validation_error_type)
-		Z_PARAM_BOOL(failure)
-	ZEND_PARSE_PARAMETERS_END();
-
-	zend_update_property_str(php_uri_ce_whatwg_url_validation_error, Z_OBJ_P(ZEND_THIS), ZEND_STRL("context"), context);
-	if (EG(exception)) {
-		RETURN_THROWS();
-	}
-
-	zend_update_property_ex(php_uri_ce_whatwg_url_validation_error, Z_OBJ_P(ZEND_THIS), ZSTR_KNOWN(ZEND_STR_TYPE), type);
-	if (EG(exception)) {
-		RETURN_THROWS();
-	}
-
-	zval failure_zv;
-	ZVAL_BOOL(&failure_zv, failure);
-	zend_update_property(php_uri_ce_whatwg_url_validation_error, Z_OBJ_P(ZEND_THIS), ZEND_STRL("failure"), &failure_zv);
-	if (EG(exception)) {
-		RETURN_THROWS();
-	}
-}
-
-static void create_whatwg_uri(INTERNAL_FUNCTION_PARAMETERS, bool is_constructor)
-{
-	zend_string *uri_str;
-	zend_object *base_url_object = NULL;
-	zval *errors = NULL;
-
-	ZEND_PARSE_PARAMETERS_START(1, 3)
-		Z_PARAM_STR(uri_str)
-		Z_PARAM_OPTIONAL
-		Z_PARAM_OBJ_OF_CLASS_OR_NULL(base_url_object, php_uri_ce_whatwg_url)
-		Z_PARAM_ZVAL(errors)
-	ZEND_PARSE_PARAMETERS_END();
-
-	php_uri_instantiate_uri(INTERNAL_FUNCTION_PARAM_PASSTHRU,
-		uri_str, base_url_object ? php_uri_object_from_obj(base_url_object) : NULL, is_constructor, is_constructor, errors);
-}
-
-PHP_METHOD(Uri_WhatWg_Url, parse)
-{
-	create_whatwg_uri(INTERNAL_FUNCTION_PARAM_PASSTHRU, false);
-}
-
-PHP_METHOD(Uri_WhatWg_Url, __construct)
-{
-	create_whatwg_uri(INTERNAL_FUNCTION_PARAM_PASSTHRU, true);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, getScheme)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_SCHEME, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, getRawScheme)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_SCHEME, PHP_URI_COMPONENT_READ_MODE_RAW);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, withScheme)
-{
-	php_uri_property_write_str_or_null_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_SCHEME);
-}
-
-static void rfc3986_userinfo_read(INTERNAL_FUNCTION_PARAMETERS, php_uri_component_read_mode read_mode)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
-	ZEND_ASSERT(uri_object->uri != NULL);
-
-	if (UNEXPECTED(php_uri_parser_rfc3986_userinfo_read(uri_object->uri, read_mode, return_value) == FAILURE)) {
-		zend_throw_error(NULL, "The userinfo component cannot be retrieved");
-		RETURN_THROWS();
-	}
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, getUserInfo)
-{
-	rfc3986_userinfo_read(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, getRawUserInfo)
-{
-	rfc3986_userinfo_read(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_COMPONENT_READ_MODE_RAW);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, withUserInfo)
-{
-	zend_string *value;
-
-	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_STR_OR_NULL(value)
-	ZEND_PARSE_PARAMETERS_END();
-
-	zval zv;
-	if (value == NULL) {
-		ZVAL_NULL(&zv);
-	} else {
-		ZVAL_STR(&zv, value);
-	}
-
-	php_uri_object *old_uri_object = php_uri_object_from_obj(Z_OBJ_P(ZEND_THIS));
-	ZEND_ASSERT(old_uri_object->uri != NULL);
-
-	zend_object *new_object = old_uri_object->std.handlers->clone_obj(&old_uri_object->std);
-	if (new_object == NULL) {
-		RETURN_THROWS();
-	}
-
-	/* Assign the object early. The engine will take care of destruction in
-	 * case of an exception being thrown. */
-	RETVAL_OBJ(new_object);
-
-	php_uri_object *new_uri_object = php_uri_object_from_obj(new_object);
-	ZEND_ASSERT(new_uri_object->uri != NULL);
-
-	if (UNEXPECTED(php_uri_parser_rfc3986_userinfo_write(new_uri_object->uri, &zv, NULL) == FAILURE)) {
-		RETURN_THROWS();
-	}
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, getUsername)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_USERNAME, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, getRawUsername)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_USERNAME, PHP_URI_COMPONENT_READ_MODE_RAW);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, getPassword)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_PASSWORD, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, getRawPassword)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_PASSWORD, PHP_URI_COMPONENT_READ_MODE_RAW);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, getHost)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_HOST, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, getRawHost)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_HOST, PHP_URI_COMPONENT_READ_MODE_RAW);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, withHost)
-{
-	php_uri_property_write_str_or_null_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_HOST);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, getPort)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_PORT, PHP_URI_COMPONENT_READ_MODE_RAW);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, withPort)
-{
-	php_uri_property_write_long_or_null_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_PORT);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, getPath)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_PATH, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, getRawPath)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_PATH, PHP_URI_COMPONENT_READ_MODE_RAW);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, withPath)
-{
-	php_uri_property_write_str_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_PATH);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, getQuery)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_QUERY, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, getRawQuery)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_QUERY, PHP_URI_COMPONENT_READ_MODE_RAW);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, withQuery)
-{
-	php_uri_property_write_str_or_null_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_QUERY);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, getFragment)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_FRAGMENT, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, getRawFragment)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_FRAGMENT, PHP_URI_COMPONENT_READ_MODE_RAW);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, withFragment)
-{
-	php_uri_property_write_str_or_null_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_FRAGMENT);
-}
-
-static void throw_cannot_recompose_uri_to_string(php_uri_object *object)
-{
-	zend_throw_exception_ex(php_uri_ce_error, 0, "Cannot recompose %s to a string", ZSTR_VAL(object->std.ce->name));
-}
-
-static void uri_equals(INTERNAL_FUNCTION_PARAMETERS, php_uri_object *that_object, zend_object *comparison_mode)
-{
-	php_uri_object *this_object = Z_URI_OBJECT_P(ZEND_THIS);
-	ZEND_ASSERT(this_object->uri != NULL);
-	ZEND_ASSERT(that_object->uri != NULL);
-
-	if (this_object->std.ce != that_object->std.ce &&
-		!instanceof_function(this_object->std.ce, that_object->std.ce) &&
-		!instanceof_function(that_object->std.ce, this_object->std.ce)
-	) {
-		RETURN_FALSE;
-	}
-
-	bool exclude_fragment = true;
-	if (comparison_mode) {
-		zval *case_name = zend_enum_fetch_case_name(comparison_mode);
-		exclude_fragment = zend_string_equals_literal(Z_STR_P(case_name), "ExcludeFragment");
-	}
-
-	zend_string *this_str = this_object->parser->to_string(
-		this_object->uri, PHP_URI_RECOMPOSITION_MODE_NORMALIZED_ASCII, exclude_fragment);
-	if (this_str == NULL) {
-		throw_cannot_recompose_uri_to_string(this_object);
-		RETURN_THROWS();
-	}
-
-	zend_string *that_str = that_object->parser->to_string(
-		that_object->uri, PHP_URI_RECOMPOSITION_MODE_NORMALIZED_ASCII, exclude_fragment);
-	if (that_str == NULL) {
-		zend_string_release(this_str);
-		throw_cannot_recompose_uri_to_string(that_object);
-		RETURN_THROWS();
-	}
-
-	RETVAL_BOOL(zend_string_equals(this_str, that_str));
-
-	zend_string_release(this_str);
-	zend_string_release(that_str);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, equals)
-{
-	zend_object *that_object;
-	zend_object *comparison_mode = NULL;
-
-	ZEND_PARSE_PARAMETERS_START(1, 2)
-		Z_PARAM_OBJ_OF_CLASS(that_object, php_uri_ce_rfc3986_uri)
-		Z_PARAM_OPTIONAL
-		Z_PARAM_OBJ_OF_CLASS(comparison_mode, php_uri_ce_comparison_mode)
-	ZEND_PARSE_PARAMETERS_END();
-
-	uri_equals(INTERNAL_FUNCTION_PARAM_PASSTHRU, php_uri_object_from_obj(that_object), comparison_mode);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, toRawString)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
-	ZEND_ASSERT(uri_object->uri != NULL);
-
-	zend_string *uri_str = uri_object->parser->to_string(uri_object->uri, PHP_URI_RECOMPOSITION_MODE_RAW_ASCII, false);
-	if (uri_str == NULL) {
-		throw_cannot_recompose_uri_to_string(uri_object);
-		RETURN_THROWS();
-	}
-
-	RETURN_STR(uri_str);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, toString)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
-	ZEND_ASSERT(uri_object->uri != NULL);
-
-	zend_string *uri_str = uri_object->parser->to_string(uri_object->uri, PHP_URI_RECOMPOSITION_MODE_NORMALIZED_ASCII, false);
-	if (uri_str == NULL) {
-		throw_cannot_recompose_uri_to_string(uri_object);
-		RETURN_THROWS();
-	}
-
-	RETURN_STR(uri_str);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, resolve)
-{
-	zend_string *uri_str;
-
-	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_STR(uri_str)
-	ZEND_PARSE_PARAMETERS_END();
-
-	php_uri_instantiate_uri(INTERNAL_FUNCTION_PARAM_PASSTHRU,
-		uri_str, Z_URI_OBJECT_P(ZEND_THIS), true, false, NULL);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, __serialize)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
-	ZEND_ASSERT(uri_object->uri != NULL);
-
-	/* Serialize state: "uri" key in the first array */
-	zend_string *uri_str = uri_object->parser->to_string(uri_object->uri, PHP_URI_RECOMPOSITION_MODE_RAW_ASCII, false);
-	if (uri_str == NULL) {
-		throw_cannot_recompose_uri_to_string(uri_object);
-		RETURN_THROWS();
-	}
-	zval tmp;
-	ZVAL_STR(&tmp, uri_str);
-
-	array_init(return_value);
-
-	zval arr;
-	array_init(&arr);
-	zend_hash_str_add_new(Z_ARRVAL(arr), PHP_URI_SERIALIZE_URI_FIELD_NAME, sizeof(PHP_URI_SERIALIZE_URI_FIELD_NAME) - 1, &tmp);
-	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &arr);
-
-	/* Serialize regular properties: second array */
-	ZVAL_EMPTY_ARRAY(&arr);
-	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &arr);
-}
-
-static void uri_unserialize(INTERNAL_FUNCTION_PARAMETERS)
-{
-	HashTable *data;
-
-	ZEND_PARSE_PARAMETERS_START(1, 1)
-		Z_PARAM_ARRAY_HT(data)
-	ZEND_PARSE_PARAMETERS_END();
-
-	php_uri_object *uri_object = php_uri_object_from_obj(Z_OBJ_P(ZEND_THIS));
-	if (uri_object->uri != NULL) {
-		/* Intentionally throw two exceptions for proper chaining. */
-		zend_throw_error(NULL, "Cannot modify readonly object of class %s", ZSTR_VAL(uri_object->std.ce->name));
-		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_object->std.ce->name));
-		RETURN_THROWS();
-	}
-
-	/* Verify the expected number of elements, this implicitly ensures that no additional elements are present. */
-	if (zend_hash_num_elements(data) != 2) {
-		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_object->std.ce->name));
-		RETURN_THROWS();
-	}
-
-	/* Unserialize state: "uri" key in the first array */
-	zval *arr = zend_hash_index_find(data, 0);
-	if (arr == NULL || Z_TYPE_P(arr) != IS_ARRAY) {
-		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_object->std.ce->name));
-		RETURN_THROWS();
-	}
-
-	/* Verify the expected number of elements inside the first array, this implicitly ensures that no additional elements are present. */
-	if (zend_hash_num_elements(Z_ARRVAL_P(arr)) != 1) {
-		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_object->std.ce->name));
-		RETURN_THROWS();
-	}
-
-	zval *uri_zv = zend_hash_str_find(Z_ARRVAL_P(arr), ZEND_STRL(PHP_URI_SERIALIZE_URI_FIELD_NAME));
-	if (uri_zv == NULL || Z_TYPE_P(uri_zv) != IS_STRING) {
-		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_object->std.ce->name));
-		RETURN_THROWS();
-	}
-
-	uri_object->uri = uri_object->parser->parse(Z_STRVAL_P(uri_zv), Z_STRLEN_P(uri_zv), NULL, NULL, true);
-	if (uri_object->uri == NULL) {
-		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_object->std.ce->name));
-		RETURN_THROWS();
-	}
-
-	/* Unserialize regular properties: second array */
-	arr = zend_hash_index_find(data, 1);
-	if (arr == NULL || Z_TYPE_P(arr) != IS_ARRAY) {
-		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_object->std.ce->name));
-		RETURN_THROWS();
-	}
-
-	/* Verify that there is no regular property in the second array, because the URI classes have no properties and they are final. */
-	if (zend_hash_num_elements(Z_ARRVAL_P(arr)) > 0) {
-		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_object->std.ce->name));
-		RETURN_THROWS();
-	}
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, __unserialize)
-{
-	uri_unserialize(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-}
-
-PHP_METHOD(Uri_Rfc3986_Uri, __debugInfo)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
-
-	RETURN_ARR(uri_get_debug_properties(uri_object));
-}
-
-PHP_METHOD(Uri_WhatWg_Url, getScheme)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_SCHEME, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
-}
-
-PHP_METHOD(Uri_WhatWg_Url, withScheme)
-{
-	php_uri_property_write_str_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_SCHEME);
-}
-
-PHP_METHOD(Uri_WhatWg_Url, withUsername)
-{
-	php_uri_property_write_str_or_null_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_USERNAME);
-}
-
-PHP_METHOD(Uri_WhatWg_Url, withPassword)
-{
-	php_uri_property_write_str_or_null_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_PASSWORD);
-}
-
-PHP_METHOD(Uri_WhatWg_Url, getAsciiHost)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_HOST, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
-}
-
-PHP_METHOD(Uri_WhatWg_Url, getUnicodeHost)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_HOST, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_UNICODE);
-}
-
-PHP_METHOD(Uri_WhatWg_Url, getFragment)
-{
-	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_FRAGMENT, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_UNICODE);
-}
-
-PHP_METHOD(Uri_WhatWg_Url, equals)
-{
-	zend_object *that_object;
-	zend_object *comparison_mode = NULL;
-
-	ZEND_PARSE_PARAMETERS_START(1, 2)
-		Z_PARAM_OBJ_OF_CLASS(that_object, php_uri_ce_whatwg_url)
-		Z_PARAM_OPTIONAL
-		Z_PARAM_OBJ_OF_CLASS(comparison_mode, php_uri_ce_comparison_mode)
-	ZEND_PARSE_PARAMETERS_END();
-
-	uri_equals(INTERNAL_FUNCTION_PARAM_PASSTHRU, php_uri_object_from_obj(that_object), comparison_mode);
-}
-
-PHP_METHOD(Uri_WhatWg_Url, toUnicodeString)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	zend_object *this_object = Z_OBJ_P(ZEND_THIS);
-	php_uri_object *uri_object = php_uri_object_from_obj(this_object);
-	ZEND_ASSERT(uri_object->uri != NULL);
-
-	RETURN_STR(uri_object->parser->to_string(uri_object->uri, PHP_URI_RECOMPOSITION_MODE_RAW_UNICODE, false));
-}
-
-PHP_METHOD(Uri_WhatWg_Url, toAsciiString)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	zend_object *this_object = Z_OBJ_P(ZEND_THIS);
-	php_uri_object *uri_object = php_uri_object_from_obj(this_object);
-	ZEND_ASSERT(uri_object->uri != NULL);
-
-	RETURN_STR(uri_object->parser->to_string(uri_object->uri, PHP_URI_RECOMPOSITION_MODE_RAW_ASCII, false));
-}
-
-PHP_METHOD(Uri_WhatWg_Url, resolve)
-{
-	zend_string *uri_str;
-	zval *errors = NULL;
-
-	ZEND_PARSE_PARAMETERS_START(1, 2)
-		Z_PARAM_STR(uri_str)
-		Z_PARAM_OPTIONAL
-		Z_PARAM_ZVAL(errors)
-	ZEND_PARSE_PARAMETERS_END();
-
-	php_uri_instantiate_uri(INTERNAL_FUNCTION_PARAM_PASSTHRU,
-		uri_str, Z_URI_OBJECT_P(ZEND_THIS), true, false, errors);
-}
-
-PHP_METHOD(Uri_WhatWg_Url, __serialize)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_uri_object *this_object = Z_URI_OBJECT_P(ZEND_THIS);
-	ZEND_ASSERT(this_object->uri != NULL);
-
-	/* Serialize state: "uri" key in the first array */
-	zend_string *uri_str = this_object->parser->to_string(this_object->uri, PHP_URI_RECOMPOSITION_MODE_RAW_ASCII, false);
-	if (uri_str == NULL) {
-		throw_cannot_recompose_uri_to_string(this_object);
-		RETURN_THROWS();
-	}
-	zval tmp;
-	ZVAL_STR(&tmp, uri_str);
-
-	array_init(return_value);
-
-	zval arr;
-	array_init(&arr);
-	zend_hash_str_add_new(Z_ARRVAL(arr), ZEND_STRL(PHP_URI_SERIALIZE_URI_FIELD_NAME), &tmp);
-	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &arr);
-
-	/* Serialize regular properties: second array */
-	ZVAL_EMPTY_ARRAY(&arr);
-	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &arr);
-}
-
-PHP_METHOD(Uri_WhatWg_Url, __unserialize)
-{
-	uri_unserialize(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-}
-
-PHP_METHOD(Uri_WhatWg_Url, __debugInfo)
-{
-	ZEND_PARSE_PARAMETERS_NONE();
-
-	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
-
-	RETURN_ARR(uri_get_debug_properties(uri_object));
-}
-
-PHPAPI php_uri_object *php_uri_object_create(zend_class_entry *class_type, const php_uri_parser *parser)
-{
-	php_uri_object *uri_object = zend_object_alloc(sizeof(*uri_object), class_type);
-
-	zend_object_std_init(&uri_object->std, class_type);
-	object_properties_init(&uri_object->std, class_type);
-
-	uri_object->parser = parser;
-	uri_object->uri = NULL;
-
-	return uri_object;
-}
-
 static zend_object *php_uri_object_create_rfc3986(zend_class_entry *ce)
 {
 	return &php_uri_object_create(ce, &php_uri_parser_rfc3986)->std;
@@ -1030,52 +297,13 @@ static zend_object *php_uri_object_create_whatwg(zend_class_entry *ce)
 	return &php_uri_object_create(ce, &php_uri_parser_whatwg)->std;
 }
 
-PHPAPI void php_uri_object_handler_free(zend_object *object)
-{
-	php_uri_object *uri_object = php_uri_object_from_obj(object);
-
-	uri_object->parser->destroy(uri_object->uri);
-	zend_object_std_dtor(&uri_object->std);
-}
-
-PHPAPI zend_object *php_uri_object_handler_clone(zend_object *object)
-{
-	php_uri_object *uri_object = php_uri_object_from_obj(object);
-
-	ZEND_ASSERT(uri_object->uri != NULL);
-
-	php_uri_object *new_uri_object = php_uri_object_from_obj(object->ce->create_object(object->ce));
-	ZEND_ASSERT(new_uri_object->parser == uri_object->parser);
-
-	void *uri = uri_object->parser->clone(uri_object->uri);
-	ZEND_ASSERT(uri != NULL);
-
-	new_uri_object->uri = uri;
-
-	zend_objects_clone_members(&new_uri_object->std, &uri_object->std);
-
-	return &new_uri_object->std;
-}
-
-PHPAPI zend_result php_uri_parser_register(const php_uri_parser *uri_parser)
-{
-	zend_string *key = zend_string_init_interned(uri_parser->name, strlen(uri_parser->name), true);
-
-	ZEND_ASSERT(uri_parser->name != NULL);
-	ZEND_ASSERT(uri_parser->parse != NULL);
-	ZEND_ASSERT(uri_parser->clone != NULL || strcmp(uri_parser->name, PHP_URI_PARSER_PHP_PARSE_URL) == 0);
-	ZEND_ASSERT(uri_parser->to_string != NULL || strcmp(uri_parser->name, PHP_URI_PARSER_PHP_PARSE_URL) == 0);
-	ZEND_ASSERT(uri_parser->destroy != NULL);
-
-	zend_result result = zend_hash_add_ptr(&uri_parsers, key, (void *) uri_parser) != NULL ? SUCCESS : FAILURE;
-
-	zend_string_release_ex(key, true);
-
-	return result;
-}
-
 static PHP_MINIT_FUNCTION(uri)
 {
+	php_uri_ce_comparison_mode = register_class_Uri_UriComparisonMode();
+	php_uri_ce_exception = register_class_Uri_UriException(zend_ce_exception);
+	php_uri_ce_error = register_class_Uri_UriError(zend_ce_error);
+	php_uri_ce_invalid_uri_exception = register_class_Uri_InvalidUriException(php_uri_ce_exception);
+
 	php_uri_ce_rfc3986_uri = register_class_Uri_Rfc3986_Uri();
 	php_uri_ce_rfc3986_uri->create_object = php_uri_object_create_rfc3986;
 	php_uri_ce_rfc3986_uri->default_object_handlers = &object_handlers_rfc3986_uri;
@@ -1083,6 +311,17 @@ static PHP_MINIT_FUNCTION(uri)
 	object_handlers_rfc3986_uri.offset = XtOffsetOf(php_uri_object, std);
 	object_handlers_rfc3986_uri.free_obj = php_uri_object_handler_free;
 	object_handlers_rfc3986_uri.clone_obj = php_uri_object_handler_clone;
+
+	php_uri_ce_rfc3986_uri_type = register_class_Uri_Rfc3986_UriType();
+	php_uri_ce_rfc3986_uri_host_type = register_class_Uri_Rfc3986_UriHostType();
+	php_uri_ce_rfc3986_uri_percent_encoding_mode = register_class_Uri_Rfc3986_UriPercentEncodingMode();
+	php_uri_ce_rfc3986_uri_query_params = register_class_Uri_Rfc3986_UriQueryParams(zend_ce_countable);
+	php_uri_ce_rfc3986_uri_query_params->create_object = php_uri_object_create_rfc3986_uri_query_params;
+	php_uri_ce_rfc3986_uri_query_params->default_object_handlers = &object_handlers_rfc3986_uri_query_params;
+	memcpy(&object_handlers_rfc3986_uri_query_params, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
+	object_handlers_rfc3986_uri_query_params.offset = XtOffsetOf(php_uri_parser_rfc3986_uri_query_params_object, std);
+	object_handlers_rfc3986_uri_query_params.free_obj = php_uri_rfc3986_uri_query_params_object_handler_free;
+	object_handlers_rfc3986_uri_query_params.clone_obj = php_uri_rfc3986_uri_query_params_object_handler_clone;
 
 	php_uri_ce_whatwg_url = register_class_Uri_WhatWg_Url();
 	php_uri_ce_whatwg_url->create_object = php_uri_object_create_whatwg;
@@ -1092,13 +331,19 @@ static PHP_MINIT_FUNCTION(uri)
 	object_handlers_whatwg_uri.free_obj = php_uri_object_handler_free;
 	object_handlers_whatwg_uri.clone_obj = php_uri_object_handler_clone;
 
-	php_uri_ce_comparison_mode = register_class_Uri_UriComparisonMode();
-	php_uri_ce_exception = register_class_Uri_UriException(zend_ce_exception);
-	php_uri_ce_error = register_class_Uri_UriError(zend_ce_error);
-	php_uri_ce_invalid_uri_exception = register_class_Uri_InvalidUriException(php_uri_ce_exception);
 	php_uri_ce_whatwg_invalid_url_exception = register_class_Uri_WhatWg_InvalidUrlException(php_uri_ce_invalid_uri_exception);
 	php_uri_ce_whatwg_url_validation_error = register_class_Uri_WhatWg_UrlValidationError();
 	php_uri_ce_whatwg_url_validation_error_type = register_class_Uri_WhatWg_UrlValidationErrorType();
+
+	php_uri_ce_whatwg_url_host_type = register_class_Uri_WhatWg_UrlHostType();
+	php_uri_ce_whatwg_url_percent_encoding_mode = register_class_Uri_WhatWg_UrlPercentEncodingMode();
+	php_uri_ce_whatwg_url_query_params = register_class_Uri_WhatWg_UrlQueryParams(zend_ce_countable);
+	php_uri_ce_whatwg_url_query_params->create_object = php_uri_object_create_rfc3986_uri_query_params;
+	php_uri_ce_whatwg_url_query_params->default_object_handlers = &object_handlers_whatwg_url_query_params;
+	memcpy(&object_handlers_whatwg_url_query_params, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
+	object_handlers_whatwg_url_query_params.offset = XtOffsetOf(php_uri_parser_whatwg_url_query_params_object, std);
+	object_handlers_whatwg_url_query_params.free_obj = php_uri_whatwg_url_query_params_object_handler_free;
+	object_handlers_whatwg_url_query_params.clone_obj = php_uri_whatwg_url_query_params_object_handler_clone;
 
 	zend_hash_init(&uri_parsers, 4, NULL, NULL, true);
 

--- a/ext/uri/php_uri.stub.php
+++ b/ext/uri/php_uri.stub.php
@@ -29,9 +29,15 @@ namespace Uri\Rfc3986 {
     /** @strict-properties */
     final readonly class Uri
     {
+        public static function percentEncode(string $input, \Uri\Rfc3986\UriPercentEncodingMode $mode): string {}
+
+        public static function percentDecode(string $input, \Uri\Rfc3986\UriPercentEncodingMode $mode): string {}
+
         public static function parse(string $uri, ?\Uri\Rfc3986\Uri $baseUrl = null): ?static {}
 
         public function __construct(string $uri, ?\Uri\Rfc3986\Uri $baseUrl = null) {}
+
+        public function getUriType(): ?\Uri\Rfc3986\UriType {}
 
         public function getScheme(): ?string {}
 
@@ -57,6 +63,8 @@ namespace Uri\Rfc3986 {
 
         public function getRawHost(): ?string {}
 
+        public function getHostType(): ?\Uri\Rfc3986\UriHostType {}
+
         public function withHost(?string $host): static {}
 
         public function getPort(): ?int {}
@@ -67,13 +75,25 @@ namespace Uri\Rfc3986 {
 
         public function getRawPath(): string {}
 
+        public function getRawPathSegments(): ?array {}
+
+        public function getPathSegments(): array {}
+
         public function withPath(string $path): static {}
+
+        public function withPathSegments(array $segments, bool $addLeadingSlashForNonEmptyRelativeUri = true): static {}
 
         public function getQuery(): ?string {}
 
         public function getRawQuery(): ?string {}
 
+        public function getRawQueryParams(): ?\Uri\Rfc3986\UriQueryParams {}
+
+        public function getQueryParams(): ?\Uri\Rfc3986\UriQueryParams {}
+
         public function withQuery(?string $query): static {}
+
+        public function withQueryParams(?\Uri\Rfc3986\UriQueryParams $queryParams): static {}
 
         public function getFragment(): ?string {}
 
@@ -94,6 +114,105 @@ namespace Uri\Rfc3986 {
         public function __unserialize(array $data): void {}
 
         public function __debugInfo(): array {}
+    }
+
+    final class UriQueryParams implements \Countable
+    {
+        public static function parseRfc3986(string $queryString): ?\Uri\Rfc3986\UriQueryParams {}
+
+        public static function parseFormData(string $queryString): \Uri\Rfc3986\UriQueryParams {}
+
+        public static function fromArray(array $queryParams): \Uri\Rfc3986\UriQueryParams {}
+
+        public function __construct() {}
+
+        public function append(string $name, mixed $value): static {}
+
+        public function delete(string $name): static {}
+
+        public function deleteValue(string $name, mixed $value): static {}
+
+        public function has(string $name): bool {}
+
+        public function hasValue(string $name, mixed $value): bool {}
+
+        public function getFirst(string $name): ?string {}
+
+        public function getLast(string $name): ?string {}
+
+        public function getAll(?string $name = null): array {}
+
+        public function count(): int {}
+
+        public function set(string $name, mixed $value): static {}
+
+        public function sort(): static {}
+
+        public function toRfc3986String(): string {}
+
+        public function toFormDataString(): string {}
+
+        public function __serialize(): array {}
+
+        public function __unserialize(array $data): void {}
+
+        public function __debugInfo(): array {}
+    }
+
+/*
+    final class UriBuilder
+    {
+        public function __construct() {}
+
+        public function setScheme(?string $scheme): static {}
+
+        public function setUserInfo(#[\SensitiveParameter] ?string $userInfo): static {}
+
+        public function setHost(?string $host): static {}
+
+        public function setPath(string $path): static {}
+
+        public function setPathSegments(?array $segments): static {}
+
+        public function setQuery(?string $query): static {}
+
+        public function setQueryParams(\Uri\Rfc3986\UriQueryParams $queryParams): static {}
+
+        public function setFragment(?string $fragment): static {}
+
+        public function build(?\Uri\Rfc3986\Uri $baseUrl = null): \Uri\Rfc3986\Uri {}
+    }
+*/
+
+    enum UriPercentEncodingMode
+    {
+        case UserInfo;
+        case Host;
+        case RelativeReferencePath;
+        case RelativeReferenceFirstPathSegment;
+        case Path;
+        case PathSegment;
+        case Query;
+        case FormQuery;
+        case Fragment;
+        case AllReservedCharacters;
+        case All;
+    }
+
+    enum UriType
+    {
+        case AbsolutePathReference;
+        case RelativePathReference;
+        case NetworkPathReference;
+        case Uri;
+    }
+
+    enum UriHostType
+    {
+        case IPv4;
+        case IPv6;
+        case IPvFuture;
+        case RegisteredName;
     }
 }
 
@@ -152,6 +271,10 @@ namespace Uri\WhatWg {
     /** @strict-properties */
     final readonly class Url
     {
+        public static function percentEncode(string $input, \Uri\WhatWg\UrlPercentEncodingMode $mode): string {}
+
+        public static function percentDecode(string $input, \Uri\WhatWg\UrlPercentEncodingMode $mode): string {}
+
         /** @param array $errors */
         public static function parse(string $uri, ?\Uri\WhatWg\Url $baseUrl = null, &$errors = null): ?static {}
 
@@ -161,6 +284,8 @@ namespace Uri\WhatWg {
         public function getScheme(): string {}
 
         public function withScheme(string $scheme): static {}
+
+        public function isSpecialScheme(): bool {}
 
         /** @implementation-alias Uri\Rfc3986\Uri::getUsername */
         public function getUsername(): ?string {}
@@ -176,6 +301,8 @@ namespace Uri\WhatWg {
 
         public function getUnicodeHost(): ?string {}
 
+        public function getHostType(): ?\Uri\WhatWg\UrlHostType {}
+
         /** @implementation-alias Uri\Rfc3986\Uri::withHost */
         public function withHost(?string $host): static {}
 
@@ -188,14 +315,22 @@ namespace Uri\WhatWg {
         /** @implementation-alias Uri\Rfc3986\Uri::getPath */
         public function getPath(): string {}
 
+        public function getPathSegments(): array {}
+
         /** @implementation-alias Uri\Rfc3986\Uri::withPath */
         public function withPath(string $path): static {}
+
+        public function withPathSegments(array $segments): static {}
 
         /** @implementation-alias Uri\Rfc3986\Uri::getQuery */
         public function getQuery(): ?string {}
 
+        public function getQueryParams(): ?\Uri\WhatWg\UrlQueryParams {}
+
         /** @implementation-alias Uri\Rfc3986\Uri::withQuery */
         public function withQuery(?string $query): static {}
+
+        public function withQueryParams(?\Uri\WhatWg\UrlQueryParams $queryParams): static {}
 
         /** @implementation-alias Uri\Rfc3986\Uri::getFragment */
         public function getFragment(): ?string {}
@@ -217,5 +352,94 @@ namespace Uri\WhatWg {
         public function __unserialize(array $data): void {}
 
         public function __debugInfo(): array {}
+    }
+
+    final readonly class UrlQueryParams implements \Countable
+    {
+        public static function parse(string $queryString): \Uri\WhatWg\UrlQueryParams {}
+
+        public static function fromArray(array $queryParams): \Uri\WhatWg\UrlQueryParams {}
+
+        private function __construct() {}
+
+        public function append(string $name, mixed $value): static {}
+
+        public function delete(string $name): static {}
+
+        public function deleteValue(string $name, mixed $value): static {}
+
+        public function has(string $name): bool {}
+
+        public function hasValue(string $name, mixed $value): bool {}
+
+        public function getFirst(string $name): ?string {}
+
+        public function getLast(string $name): ?string {}
+
+        public function getAll(?string $name = null): array {}
+
+        public function count(): int {}
+
+        public function set(string $name, mixed $value): static {}
+
+        public function sort(): static {}
+
+        public function toString(): string {}
+
+        public function __serialize(): array {}
+
+        public function __unserialize(array $data): void {}
+
+        public function __debugInfo(): array {}
+    }
+
+/*
+    final class UrlBuilder
+    {
+        public function __construct() {}
+
+        public function setScheme(?string $scheme): static {}
+
+        public function setUsername(?string $username): static {}
+
+        public function setPassword(#[\SensitiveParameter] ?string $password): static {}
+
+        public function setHost(?string $host): static {}
+
+        public function setPath(string $path): static {}
+
+        public function setQuery(?string $query): static {}
+
+        public function setQueryParams(\Uri\WhatWg\UrlQueryParams $queryParams): static {}
+
+        public function setFragment(?string $fragment): static {}
+
+        /** @param array $errors
+        public function build(?\Uri\WhatWg\Url $baseUrl = null, &$errors = null): \Uri\WhatWg\Url {}
+    }
+*/
+
+    enum UrlPercentEncodingMode
+    {
+        case UserInfo;          // Let encodedCodePoints be the result of running UTF-8 percent-encode codePoint using the "userinfo percent-encode set"
+        case Host;
+        case OpaqueHost;        // UTF-8 percent-encode on input using the C0 control percent-encode set
+        case Path;              // UTF-8 percent-encode c using the "path percent-encode set"
+        case PathSegment;       // UTF-8 percent-encode c using the "path percent-encode set"
+        case OpaquePath;        // UTF-8 percent-encode c using the "C0 control percent-encode set"
+        case OpaquePathSegment; // UTF-8 percent-encode c using the "C0 control percent-encode set"
+        case Query;             // Percent-encode after encoding, with encoding, buffer, and "query percent-encode set"
+        case SpecialQuery;      // Percent-encode after encoding, with encoding, buffer, and "special-query percent-encode set"
+        case FormQuery;
+        case Fragment;          // UTF-8 percent-encode c using the fragment percent-encode set
+    }
+
+    enum UrlHostType
+    {
+        case IPv4;
+        case IPv6;
+        case Domain;
+        case Opaque;
+        case Empty;
     }
 }

--- a/ext/uri/php_uri_arginfo.h
+++ b/ext/uri/php_uri_arginfo.h
@@ -1,5 +1,12 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f3c524798d1933a400cc9377cfbfdcbaf77b87f0 */
+ * Stub hash: 8442e85134a9d555e6a6f59bcd6a80c9961d26cb */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_Uri_percentEncode, 0, 2, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, input, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO(0, mode, Uri\\Rfc3986\\\125riPercentEncodingMode, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Uri_Rfc3986_Uri_percentDecode arginfo_class_Uri_Rfc3986_Uri_percentEncode
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_Uri_parse, 0, 1, IS_STATIC, 1)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 0)
@@ -9,6 +16,9 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Uri_Rfc3986_Uri___construct, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 0)
 	ZEND_ARG_OBJ_INFO_WITH_DEFAULT_VALUE(0, baseUrl, Uri\\Rfc3986\\\125ri, 1, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Uri_Rfc3986_Uri_getUriType, 0, 0, Uri\\Rfc3986\\\125riType, 1)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_Uri_getScheme, 0, 0, IS_STRING, 1)
@@ -40,6 +50,9 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Uri_Rfc3986_Uri_getRawHost arginfo_class_Uri_Rfc3986_Uri_getScheme
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Uri_Rfc3986_Uri_getHostType, 0, 0, Uri\\Rfc3986\\\125riHostType, 1)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_Uri_withHost, 0, 1, IS_STATIC, 0)
 	ZEND_ARG_TYPE_INFO(0, host, IS_STRING, 1)
 ZEND_END_ARG_INFO()
@@ -56,16 +69,36 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Uri_Rfc3986_Uri_getRawPath arginfo_class_Uri_Rfc3986_Uri_getPath
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_Uri_getRawPathSegments, 0, 0, IS_ARRAY, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_Uri_getPathSegments, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_Uri_withPath, 0, 1, IS_STATIC, 0)
 	ZEND_ARG_TYPE_INFO(0, path, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_Uri_withPathSegments, 0, 1, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, segments, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, addLeadingSlashForNonEmptyRelativeUri, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Uri_Rfc3986_Uri_getQuery arginfo_class_Uri_Rfc3986_Uri_getScheme
 
 #define arginfo_class_Uri_Rfc3986_Uri_getRawQuery arginfo_class_Uri_Rfc3986_Uri_getScheme
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Uri_Rfc3986_Uri_getRawQueryParams, 0, 0, Uri\\Rfc3986\\\125riQueryParams, 1)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Uri_Rfc3986_Uri_getQueryParams arginfo_class_Uri_Rfc3986_Uri_getRawQueryParams
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_Uri_withQuery, 0, 1, IS_STATIC, 0)
 	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_Uri_withQueryParams, 0, 1, IS_STATIC, 0)
+	ZEND_ARG_OBJ_INFO(0, queryParams, Uri\\Rfc3986\\\125riQueryParams, 1)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Uri_Rfc3986_Uri_getFragment arginfo_class_Uri_Rfc3986_Uri_getScheme
@@ -89,14 +122,76 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_Uri_resolve, 0
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_Uri___serialize, 0, 0, IS_ARRAY, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_class_Uri_Rfc3986_Uri___serialize arginfo_class_Uri_Rfc3986_Uri_getPathSegments
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_Uri___unserialize, 0, 1, IS_VOID, 0)
 	ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Uri_Rfc3986_Uri___debugInfo arginfo_class_Uri_Rfc3986_Uri___serialize
+#define arginfo_class_Uri_Rfc3986_Uri___debugInfo arginfo_class_Uri_Rfc3986_Uri_getPathSegments
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Uri_Rfc3986_UriQueryParams_parseRfc3986, 0, 1, Uri\\Rfc3986\\\125riQueryParams, 1)
+	ZEND_ARG_TYPE_INFO(0, queryString, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Uri_Rfc3986_UriQueryParams_parseFormData, 0, 1, Uri\\Rfc3986\\\125riQueryParams, 0)
+	ZEND_ARG_TYPE_INFO(0, queryString, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Uri_Rfc3986_UriQueryParams_fromArray, 0, 1, Uri\\Rfc3986\\\125riQueryParams, 0)
+	ZEND_ARG_TYPE_INFO(0, queryParams, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Uri_Rfc3986_UriQueryParams___construct, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_UriQueryParams_append, 0, 2, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_UriQueryParams_delete, 0, 1, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Uri_Rfc3986_UriQueryParams_deleteValue arginfo_class_Uri_Rfc3986_UriQueryParams_append
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_UriQueryParams_has, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_UriQueryParams_hasValue, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_UriQueryParams_getFirst, 0, 1, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Uri_Rfc3986_UriQueryParams_getLast arginfo_class_Uri_Rfc3986_UriQueryParams_getFirst
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_UriQueryParams_getAll, 0, 0, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, name, IS_STRING, 1, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_UriQueryParams_count, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Uri_Rfc3986_UriQueryParams_set arginfo_class_Uri_Rfc3986_UriQueryParams_append
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_Rfc3986_UriQueryParams_sort, 0, 0, IS_STATIC, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Uri_Rfc3986_UriQueryParams_toRfc3986String arginfo_class_Uri_Rfc3986_Uri_getPath
+
+#define arginfo_class_Uri_Rfc3986_UriQueryParams_toFormDataString arginfo_class_Uri_Rfc3986_Uri_getPath
+
+#define arginfo_class_Uri_Rfc3986_UriQueryParams___serialize arginfo_class_Uri_Rfc3986_Uri_getPathSegments
+
+#define arginfo_class_Uri_Rfc3986_UriQueryParams___unserialize arginfo_class_Uri_Rfc3986_Uri___unserialize
+
+#define arginfo_class_Uri_Rfc3986_UriQueryParams___debugInfo arginfo_class_Uri_Rfc3986_Uri_getPathSegments
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Uri_WhatWg_InvalidUrlException___construct, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, message, IS_STRING, 0, "\"\"")
@@ -110,6 +205,13 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Uri_WhatWg_UrlValidationError___construct, 
 	ZEND_ARG_OBJ_INFO(0, type, Uri\\WhatWg\\\125rlValidationErrorType, 0)
 	ZEND_ARG_TYPE_INFO(0, failure, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_WhatWg_Url_percentEncode, 0, 2, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, input, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO(0, mode, Uri\\WhatWg\\\125rlPercentEncodingMode, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Uri_WhatWg_Url_percentDecode arginfo_class_Uri_WhatWg_Url_percentEncode
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_WhatWg_Url_parse, 0, 1, IS_STATIC, 1)
 	ZEND_ARG_TYPE_INFO(0, uri, IS_STRING, 0)
@@ -129,6 +231,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_WhatWg_Url_withScheme,
 	ZEND_ARG_TYPE_INFO(0, scheme, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_WhatWg_Url_isSpecialScheme, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
 #define arginfo_class_Uri_WhatWg_Url_getUsername arginfo_class_Uri_Rfc3986_Uri_getScheme
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_WhatWg_Url_withUsername, 0, 1, IS_STATIC, 0)
@@ -145,6 +250,9 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Uri_WhatWg_Url_getUnicodeHost arginfo_class_Uri_Rfc3986_Uri_getScheme
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Uri_WhatWg_Url_getHostType, 0, 0, Uri\\WhatWg\\\125rlHostType, 1)
+ZEND_END_ARG_INFO()
+
 #define arginfo_class_Uri_WhatWg_Url_withHost arginfo_class_Uri_Rfc3986_Uri_withHost
 
 #define arginfo_class_Uri_WhatWg_Url_getPort arginfo_class_Uri_Rfc3986_Uri_getPort
@@ -153,11 +261,24 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Uri_WhatWg_Url_getPath arginfo_class_Uri_Rfc3986_Uri_getPath
 
+#define arginfo_class_Uri_WhatWg_Url_getPathSegments arginfo_class_Uri_Rfc3986_Uri_getPathSegments
+
 #define arginfo_class_Uri_WhatWg_Url_withPath arginfo_class_Uri_Rfc3986_Uri_withPath
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_WhatWg_Url_withPathSegments, 0, 1, IS_STATIC, 0)
+	ZEND_ARG_TYPE_INFO(0, segments, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
 
 #define arginfo_class_Uri_WhatWg_Url_getQuery arginfo_class_Uri_Rfc3986_Uri_getScheme
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Uri_WhatWg_Url_getQueryParams, 0, 0, Uri\\WhatWg\\\125rlQueryParams, 1)
+ZEND_END_ARG_INFO()
+
 #define arginfo_class_Uri_WhatWg_Url_withQuery arginfo_class_Uri_Rfc3986_Uri_withQuery
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_WhatWg_Url_withQueryParams, 0, 1, IS_STATIC, 0)
+	ZEND_ARG_OBJ_INFO(0, queryParams, Uri\\WhatWg\\\125rlQueryParams, 1)
+ZEND_END_ARG_INFO()
 
 #define arginfo_class_Uri_WhatWg_Url_getFragment arginfo_class_Uri_Rfc3986_Uri_getScheme
 
@@ -177,14 +298,57 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Uri_WhatWg_Url_resolve, 0,
 	ZEND_ARG_INFO_WITH_DEFAULT_VALUE(1, softErrors, "null")
 ZEND_END_ARG_INFO()
 
-#define arginfo_class_Uri_WhatWg_Url___serialize arginfo_class_Uri_Rfc3986_Uri___serialize
+#define arginfo_class_Uri_WhatWg_Url___serialize arginfo_class_Uri_Rfc3986_Uri_getPathSegments
 
 #define arginfo_class_Uri_WhatWg_Url___unserialize arginfo_class_Uri_Rfc3986_Uri___unserialize
 
-#define arginfo_class_Uri_WhatWg_Url___debugInfo arginfo_class_Uri_Rfc3986_Uri___serialize
+#define arginfo_class_Uri_WhatWg_Url___debugInfo arginfo_class_Uri_Rfc3986_Uri_getPathSegments
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Uri_WhatWg_UrlQueryParams_parse, 0, 1, Uri\\WhatWg\\\125rlQueryParams, 0)
+	ZEND_ARG_TYPE_INFO(0, queryString, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Uri_WhatWg_UrlQueryParams_fromArray, 0, 1, Uri\\WhatWg\\\125rlQueryParams, 0)
+	ZEND_ARG_TYPE_INFO(0, queryParams, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Uri_WhatWg_UrlQueryParams___construct arginfo_class_Uri_Rfc3986_UriQueryParams___construct
+
+#define arginfo_class_Uri_WhatWg_UrlQueryParams_append arginfo_class_Uri_Rfc3986_UriQueryParams_append
+
+#define arginfo_class_Uri_WhatWg_UrlQueryParams_delete arginfo_class_Uri_Rfc3986_UriQueryParams_delete
+
+#define arginfo_class_Uri_WhatWg_UrlQueryParams_deleteValue arginfo_class_Uri_Rfc3986_UriQueryParams_append
+
+#define arginfo_class_Uri_WhatWg_UrlQueryParams_has arginfo_class_Uri_Rfc3986_UriQueryParams_has
+
+#define arginfo_class_Uri_WhatWg_UrlQueryParams_hasValue arginfo_class_Uri_Rfc3986_UriQueryParams_hasValue
+
+#define arginfo_class_Uri_WhatWg_UrlQueryParams_getFirst arginfo_class_Uri_Rfc3986_UriQueryParams_getFirst
+
+#define arginfo_class_Uri_WhatWg_UrlQueryParams_getLast arginfo_class_Uri_Rfc3986_UriQueryParams_getFirst
+
+#define arginfo_class_Uri_WhatWg_UrlQueryParams_getAll arginfo_class_Uri_Rfc3986_UriQueryParams_getAll
+
+#define arginfo_class_Uri_WhatWg_UrlQueryParams_count arginfo_class_Uri_Rfc3986_UriQueryParams_count
+
+#define arginfo_class_Uri_WhatWg_UrlQueryParams_set arginfo_class_Uri_Rfc3986_UriQueryParams_append
+
+#define arginfo_class_Uri_WhatWg_UrlQueryParams_sort arginfo_class_Uri_Rfc3986_UriQueryParams_sort
+
+#define arginfo_class_Uri_WhatWg_UrlQueryParams_toString arginfo_class_Uri_Rfc3986_Uri_getPath
+
+#define arginfo_class_Uri_WhatWg_UrlQueryParams___serialize arginfo_class_Uri_Rfc3986_Uri_getPathSegments
+
+#define arginfo_class_Uri_WhatWg_UrlQueryParams___unserialize arginfo_class_Uri_Rfc3986_Uri___unserialize
+
+#define arginfo_class_Uri_WhatWg_UrlQueryParams___debugInfo arginfo_class_Uri_Rfc3986_Uri_getPathSegments
+
+ZEND_METHOD(Uri_Rfc3986_Uri, percentEncode);
+ZEND_METHOD(Uri_Rfc3986_Uri, percentDecode);
 ZEND_METHOD(Uri_Rfc3986_Uri, parse);
 ZEND_METHOD(Uri_Rfc3986_Uri, __construct);
+ZEND_METHOD(Uri_Rfc3986_Uri, getUriType);
 ZEND_METHOD(Uri_Rfc3986_Uri, getScheme);
 ZEND_METHOD(Uri_Rfc3986_Uri, getRawScheme);
 ZEND_METHOD(Uri_Rfc3986_Uri, withScheme);
@@ -197,15 +361,22 @@ ZEND_METHOD(Uri_Rfc3986_Uri, getPassword);
 ZEND_METHOD(Uri_Rfc3986_Uri, getRawPassword);
 ZEND_METHOD(Uri_Rfc3986_Uri, getHost);
 ZEND_METHOD(Uri_Rfc3986_Uri, getRawHost);
+ZEND_METHOD(Uri_Rfc3986_Uri, getHostType);
 ZEND_METHOD(Uri_Rfc3986_Uri, withHost);
 ZEND_METHOD(Uri_Rfc3986_Uri, getPort);
 ZEND_METHOD(Uri_Rfc3986_Uri, withPort);
 ZEND_METHOD(Uri_Rfc3986_Uri, getPath);
 ZEND_METHOD(Uri_Rfc3986_Uri, getRawPath);
+ZEND_METHOD(Uri_Rfc3986_Uri, getRawPathSegments);
+ZEND_METHOD(Uri_Rfc3986_Uri, getPathSegments);
 ZEND_METHOD(Uri_Rfc3986_Uri, withPath);
+ZEND_METHOD(Uri_Rfc3986_Uri, withPathSegments);
 ZEND_METHOD(Uri_Rfc3986_Uri, getQuery);
 ZEND_METHOD(Uri_Rfc3986_Uri, getRawQuery);
+ZEND_METHOD(Uri_Rfc3986_Uri, getRawQueryParams);
+ZEND_METHOD(Uri_Rfc3986_Uri, getQueryParams);
 ZEND_METHOD(Uri_Rfc3986_Uri, withQuery);
+ZEND_METHOD(Uri_Rfc3986_Uri, withQueryParams);
 ZEND_METHOD(Uri_Rfc3986_Uri, getFragment);
 ZEND_METHOD(Uri_Rfc3986_Uri, getRawFragment);
 ZEND_METHOD(Uri_Rfc3986_Uri, withFragment);
@@ -216,16 +387,44 @@ ZEND_METHOD(Uri_Rfc3986_Uri, resolve);
 ZEND_METHOD(Uri_Rfc3986_Uri, __serialize);
 ZEND_METHOD(Uri_Rfc3986_Uri, __unserialize);
 ZEND_METHOD(Uri_Rfc3986_Uri, __debugInfo);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, parseRfc3986);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, parseFormData);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, fromArray);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, __construct);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, append);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, delete);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, deleteValue);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, has);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, hasValue);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, getFirst);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, getLast);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, getAll);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, count);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, set);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, sort);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, toRfc3986String);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, toFormDataString);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, __serialize);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, __unserialize);
+ZEND_METHOD(Uri_Rfc3986_UriQueryParams, __debugInfo);
 ZEND_METHOD(Uri_WhatWg_InvalidUrlException, __construct);
 ZEND_METHOD(Uri_WhatWg_UrlValidationError, __construct);
+ZEND_METHOD(Uri_WhatWg_Url, percentEncode);
+ZEND_METHOD(Uri_WhatWg_Url, percentDecode);
 ZEND_METHOD(Uri_WhatWg_Url, parse);
 ZEND_METHOD(Uri_WhatWg_Url, __construct);
 ZEND_METHOD(Uri_WhatWg_Url, getScheme);
 ZEND_METHOD(Uri_WhatWg_Url, withScheme);
+ZEND_METHOD(Uri_WhatWg_Url, isSpecialScheme);
 ZEND_METHOD(Uri_WhatWg_Url, withUsername);
 ZEND_METHOD(Uri_WhatWg_Url, withPassword);
 ZEND_METHOD(Uri_WhatWg_Url, getAsciiHost);
 ZEND_METHOD(Uri_WhatWg_Url, getUnicodeHost);
+ZEND_METHOD(Uri_WhatWg_Url, getHostType);
+ZEND_METHOD(Uri_WhatWg_Url, getPathSegments);
+ZEND_METHOD(Uri_WhatWg_Url, withPathSegments);
+ZEND_METHOD(Uri_WhatWg_Url, getQueryParams);
+ZEND_METHOD(Uri_WhatWg_Url, withQueryParams);
 ZEND_METHOD(Uri_WhatWg_Url, equals);
 ZEND_METHOD(Uri_WhatWg_Url, toAsciiString);
 ZEND_METHOD(Uri_WhatWg_Url, toUnicodeString);
@@ -233,10 +432,31 @@ ZEND_METHOD(Uri_WhatWg_Url, resolve);
 ZEND_METHOD(Uri_WhatWg_Url, __serialize);
 ZEND_METHOD(Uri_WhatWg_Url, __unserialize);
 ZEND_METHOD(Uri_WhatWg_Url, __debugInfo);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, parse);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, fromArray);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, __construct);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, append);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, delete);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, deleteValue);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, has);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, hasValue);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, getFirst);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, getLast);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, getAll);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, count);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, set);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, sort);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, toString);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, __serialize);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, __unserialize);
+ZEND_METHOD(Uri_WhatWg_UrlQueryParams, __debugInfo);
 
 static const zend_function_entry class_Uri_Rfc3986_Uri_methods[] = {
+	ZEND_ME(Uri_Rfc3986_Uri, percentEncode, arginfo_class_Uri_Rfc3986_Uri_percentEncode, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(Uri_Rfc3986_Uri, percentDecode, arginfo_class_Uri_Rfc3986_Uri_percentDecode, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(Uri_Rfc3986_Uri, parse, arginfo_class_Uri_Rfc3986_Uri_parse, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(Uri_Rfc3986_Uri, __construct, arginfo_class_Uri_Rfc3986_Uri___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_Uri, getUriType, arginfo_class_Uri_Rfc3986_Uri_getUriType, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, getScheme, arginfo_class_Uri_Rfc3986_Uri_getScheme, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, getRawScheme, arginfo_class_Uri_Rfc3986_Uri_getRawScheme, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, withScheme, arginfo_class_Uri_Rfc3986_Uri_withScheme, ZEND_ACC_PUBLIC)
@@ -249,15 +469,22 @@ static const zend_function_entry class_Uri_Rfc3986_Uri_methods[] = {
 	ZEND_ME(Uri_Rfc3986_Uri, getRawPassword, arginfo_class_Uri_Rfc3986_Uri_getRawPassword, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, getHost, arginfo_class_Uri_Rfc3986_Uri_getHost, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, getRawHost, arginfo_class_Uri_Rfc3986_Uri_getRawHost, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_Uri, getHostType, arginfo_class_Uri_Rfc3986_Uri_getHostType, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, withHost, arginfo_class_Uri_Rfc3986_Uri_withHost, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, getPort, arginfo_class_Uri_Rfc3986_Uri_getPort, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, withPort, arginfo_class_Uri_Rfc3986_Uri_withPort, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, getPath, arginfo_class_Uri_Rfc3986_Uri_getPath, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, getRawPath, arginfo_class_Uri_Rfc3986_Uri_getRawPath, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_Uri, getRawPathSegments, arginfo_class_Uri_Rfc3986_Uri_getRawPathSegments, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_Uri, getPathSegments, arginfo_class_Uri_Rfc3986_Uri_getPathSegments, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, withPath, arginfo_class_Uri_Rfc3986_Uri_withPath, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_Uri, withPathSegments, arginfo_class_Uri_Rfc3986_Uri_withPathSegments, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, getQuery, arginfo_class_Uri_Rfc3986_Uri_getQuery, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, getRawQuery, arginfo_class_Uri_Rfc3986_Uri_getRawQuery, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_Uri, getRawQueryParams, arginfo_class_Uri_Rfc3986_Uri_getRawQueryParams, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_Uri, getQueryParams, arginfo_class_Uri_Rfc3986_Uri_getQueryParams, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, withQuery, arginfo_class_Uri_Rfc3986_Uri_withQuery, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_Uri, withQueryParams, arginfo_class_Uri_Rfc3986_Uri_withQueryParams, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, getFragment, arginfo_class_Uri_Rfc3986_Uri_getFragment, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, getRawFragment, arginfo_class_Uri_Rfc3986_Uri_getRawFragment, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, withFragment, arginfo_class_Uri_Rfc3986_Uri_withFragment, ZEND_ACC_PUBLIC)
@@ -268,6 +495,30 @@ static const zend_function_entry class_Uri_Rfc3986_Uri_methods[] = {
 	ZEND_ME(Uri_Rfc3986_Uri, __serialize, arginfo_class_Uri_Rfc3986_Uri___serialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, __unserialize, arginfo_class_Uri_Rfc3986_Uri___unserialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_Rfc3986_Uri, __debugInfo, arginfo_class_Uri_Rfc3986_Uri___debugInfo, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+static const zend_function_entry class_Uri_Rfc3986_UriQueryParams_methods[] = {
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, parseRfc3986, arginfo_class_Uri_Rfc3986_UriQueryParams_parseRfc3986, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, parseFormData, arginfo_class_Uri_Rfc3986_UriQueryParams_parseFormData, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, fromArray, arginfo_class_Uri_Rfc3986_UriQueryParams_fromArray, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, __construct, arginfo_class_Uri_Rfc3986_UriQueryParams___construct, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, append, arginfo_class_Uri_Rfc3986_UriQueryParams_append, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, delete, arginfo_class_Uri_Rfc3986_UriQueryParams_delete, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, deleteValue, arginfo_class_Uri_Rfc3986_UriQueryParams_deleteValue, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, has, arginfo_class_Uri_Rfc3986_UriQueryParams_has, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, hasValue, arginfo_class_Uri_Rfc3986_UriQueryParams_hasValue, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, getFirst, arginfo_class_Uri_Rfc3986_UriQueryParams_getFirst, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, getLast, arginfo_class_Uri_Rfc3986_UriQueryParams_getLast, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, getAll, arginfo_class_Uri_Rfc3986_UriQueryParams_getAll, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, count, arginfo_class_Uri_Rfc3986_UriQueryParams_count, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, set, arginfo_class_Uri_Rfc3986_UriQueryParams_set, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, sort, arginfo_class_Uri_Rfc3986_UriQueryParams_sort, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, toRfc3986String, arginfo_class_Uri_Rfc3986_UriQueryParams_toRfc3986String, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, toFormDataString, arginfo_class_Uri_Rfc3986_UriQueryParams_toFormDataString, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, __serialize, arginfo_class_Uri_Rfc3986_UriQueryParams___serialize, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, __unserialize, arginfo_class_Uri_Rfc3986_UriQueryParams___unserialize, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_Rfc3986_UriQueryParams, __debugInfo, arginfo_class_Uri_Rfc3986_UriQueryParams___debugInfo, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -282,23 +533,31 @@ static const zend_function_entry class_Uri_WhatWg_UrlValidationError_methods[] =
 };
 
 static const zend_function_entry class_Uri_WhatWg_Url_methods[] = {
+	ZEND_ME(Uri_WhatWg_Url, percentEncode, arginfo_class_Uri_WhatWg_Url_percentEncode, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(Uri_WhatWg_Url, percentDecode, arginfo_class_Uri_WhatWg_Url_percentDecode, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(Uri_WhatWg_Url, parse, arginfo_class_Uri_WhatWg_Url_parse, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(Uri_WhatWg_Url, __construct, arginfo_class_Uri_WhatWg_Url___construct, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_WhatWg_Url, getScheme, arginfo_class_Uri_WhatWg_Url_getScheme, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_WhatWg_Url, withScheme, arginfo_class_Uri_WhatWg_Url_withScheme, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_WhatWg_Url, isSpecialScheme, arginfo_class_Uri_WhatWg_Url_isSpecialScheme, ZEND_ACC_PUBLIC)
 	ZEND_RAW_FENTRY("getUsername", zim_Uri_Rfc3986_Uri_getUsername, arginfo_class_Uri_WhatWg_Url_getUsername, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_ME(Uri_WhatWg_Url, withUsername, arginfo_class_Uri_WhatWg_Url_withUsername, ZEND_ACC_PUBLIC)
 	ZEND_RAW_FENTRY("getPassword", zim_Uri_Rfc3986_Uri_getPassword, arginfo_class_Uri_WhatWg_Url_getPassword, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_ME(Uri_WhatWg_Url, withPassword, arginfo_class_Uri_WhatWg_Url_withPassword, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_WhatWg_Url, getAsciiHost, arginfo_class_Uri_WhatWg_Url_getAsciiHost, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_WhatWg_Url, getUnicodeHost, arginfo_class_Uri_WhatWg_Url_getUnicodeHost, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_WhatWg_Url, getHostType, arginfo_class_Uri_WhatWg_Url_getHostType, ZEND_ACC_PUBLIC)
 	ZEND_RAW_FENTRY("withHost", zim_Uri_Rfc3986_Uri_withHost, arginfo_class_Uri_WhatWg_Url_withHost, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("getPort", zim_Uri_Rfc3986_Uri_getPort, arginfo_class_Uri_WhatWg_Url_getPort, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("withPort", zim_Uri_Rfc3986_Uri_withPort, arginfo_class_Uri_WhatWg_Url_withPort, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("getPath", zim_Uri_Rfc3986_Uri_getPath, arginfo_class_Uri_WhatWg_Url_getPath, ZEND_ACC_PUBLIC, NULL, NULL)
+	ZEND_ME(Uri_WhatWg_Url, getPathSegments, arginfo_class_Uri_WhatWg_Url_getPathSegments, ZEND_ACC_PUBLIC)
 	ZEND_RAW_FENTRY("withPath", zim_Uri_Rfc3986_Uri_withPath, arginfo_class_Uri_WhatWg_Url_withPath, ZEND_ACC_PUBLIC, NULL, NULL)
+	ZEND_ME(Uri_WhatWg_Url, withPathSegments, arginfo_class_Uri_WhatWg_Url_withPathSegments, ZEND_ACC_PUBLIC)
 	ZEND_RAW_FENTRY("getQuery", zim_Uri_Rfc3986_Uri_getQuery, arginfo_class_Uri_WhatWg_Url_getQuery, ZEND_ACC_PUBLIC, NULL, NULL)
+	ZEND_ME(Uri_WhatWg_Url, getQueryParams, arginfo_class_Uri_WhatWg_Url_getQueryParams, ZEND_ACC_PUBLIC)
 	ZEND_RAW_FENTRY("withQuery", zim_Uri_Rfc3986_Uri_withQuery, arginfo_class_Uri_WhatWg_Url_withQuery, ZEND_ACC_PUBLIC, NULL, NULL)
+	ZEND_ME(Uri_WhatWg_Url, withQueryParams, arginfo_class_Uri_WhatWg_Url_withQueryParams, ZEND_ACC_PUBLIC)
 	ZEND_RAW_FENTRY("getFragment", zim_Uri_Rfc3986_Uri_getFragment, arginfo_class_Uri_WhatWg_Url_getFragment, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_RAW_FENTRY("withFragment", zim_Uri_Rfc3986_Uri_withFragment, arginfo_class_Uri_WhatWg_Url_withFragment, ZEND_ACC_PUBLIC, NULL, NULL)
 	ZEND_ME(Uri_WhatWg_Url, equals, arginfo_class_Uri_WhatWg_Url_equals, ZEND_ACC_PUBLIC)
@@ -308,6 +567,28 @@ static const zend_function_entry class_Uri_WhatWg_Url_methods[] = {
 	ZEND_ME(Uri_WhatWg_Url, __serialize, arginfo_class_Uri_WhatWg_Url___serialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_WhatWg_Url, __unserialize, arginfo_class_Uri_WhatWg_Url___unserialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Uri_WhatWg_Url, __debugInfo, arginfo_class_Uri_WhatWg_Url___debugInfo, ZEND_ACC_PUBLIC)
+	ZEND_FE_END
+};
+
+static const zend_function_entry class_Uri_WhatWg_UrlQueryParams_methods[] = {
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, parse, arginfo_class_Uri_WhatWg_UrlQueryParams_parse, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, fromArray, arginfo_class_Uri_WhatWg_UrlQueryParams_fromArray, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, __construct, arginfo_class_Uri_WhatWg_UrlQueryParams___construct, ZEND_ACC_PRIVATE)
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, append, arginfo_class_Uri_WhatWg_UrlQueryParams_append, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, delete, arginfo_class_Uri_WhatWg_UrlQueryParams_delete, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, deleteValue, arginfo_class_Uri_WhatWg_UrlQueryParams_deleteValue, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, has, arginfo_class_Uri_WhatWg_UrlQueryParams_has, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, hasValue, arginfo_class_Uri_WhatWg_UrlQueryParams_hasValue, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, getFirst, arginfo_class_Uri_WhatWg_UrlQueryParams_getFirst, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, getLast, arginfo_class_Uri_WhatWg_UrlQueryParams_getLast, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, getAll, arginfo_class_Uri_WhatWg_UrlQueryParams_getAll, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, count, arginfo_class_Uri_WhatWg_UrlQueryParams_count, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, set, arginfo_class_Uri_WhatWg_UrlQueryParams_set, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, sort, arginfo_class_Uri_WhatWg_UrlQueryParams_sort, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, toString, arginfo_class_Uri_WhatWg_UrlQueryParams_toString, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, __serialize, arginfo_class_Uri_WhatWg_UrlQueryParams___serialize, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, __unserialize, arginfo_class_Uri_WhatWg_UrlQueryParams___unserialize, ZEND_ACC_PUBLIC)
+	ZEND_ME(Uri_WhatWg_UrlQueryParams, __debugInfo, arginfo_class_Uri_WhatWg_UrlQueryParams___debugInfo, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 
@@ -361,6 +642,76 @@ static zend_class_entry *register_class_Uri_Rfc3986_Uri(void)
 
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "withuserinfo", sizeof("withuserinfo") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_Uri_Rfc3986_UriQueryParams(zend_class_entry *class_entry_Countable)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "Uri\\Rfc3986", "UriQueryParams", class_Uri_Rfc3986_UriQueryParams_methods);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL);
+	zend_class_implements(class_entry, 1, class_entry_Countable);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_Uri_Rfc3986_UriPercentEncodingMode(void)
+{
+	zend_class_entry *class_entry = zend_register_internal_enum("Uri\\Rfc3986\\UriPercentEncodingMode", IS_UNDEF, NULL);
+
+	zend_enum_add_case_cstr(class_entry, "UserInfo", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "Host", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "RelativeReferencePath", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "RelativeReferenceFirstPathSegment", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "Path", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "PathSegment", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "Query", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "FormQuery", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "Fragment", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "AllReservedCharacters", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "All", NULL);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_Uri_Rfc3986_UriType(void)
+{
+	zend_class_entry *class_entry = zend_register_internal_enum("Uri\\Rfc3986\\UriType", IS_UNDEF, NULL);
+
+	zend_enum_add_case_cstr(class_entry, "AbsolutePathReference", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "RelativePathReference", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "NetworkPathReference", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "Uri", NULL);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_Uri_Rfc3986_UriHostType(void)
+{
+	zend_class_entry *class_entry = zend_register_internal_enum("Uri\\Rfc3986\\UriHostType", IS_UNDEF, NULL);
+
+	zend_enum_add_case_cstr(class_entry, "IPv4", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "IPv6", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "IPvFuture", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "RegisteredName", NULL);
 
 	return class_entry;
 }
@@ -482,6 +833,63 @@ static zend_class_entry *register_class_Uri_WhatWg_Url(void)
 
 
 	zend_add_parameter_attribute(zend_hash_str_find_ptr(&class_entry->function_table, "withpassword", sizeof("withpassword") - 1), 0, ZSTR_KNOWN(ZEND_STR_SENSITIVEPARAMETER), 0);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_Uri_WhatWg_UrlQueryParams(zend_class_entry *class_entry_Countable)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_NS_CLASS_ENTRY(ce, "Uri\\WhatWg", "UrlQueryParams", class_Uri_WhatWg_UrlQueryParams_methods);
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, ZEND_ACC_FINAL|ZEND_ACC_READONLY_CLASS);
+	zend_class_implements(class_entry, 1, class_entry_Countable);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_Uri_WhatWg_UrlPercentEncodingMode(void)
+{
+	zend_class_entry *class_entry = zend_register_internal_enum("Uri\\WhatWg\\UrlPercentEncodingMode", IS_UNDEF, NULL);
+
+	zend_enum_add_case_cstr(class_entry, "UserInfo", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "Host", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "OpaqueHost", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "Path", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "PathSegment", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "OpaquePath", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "OpaquePathSegment", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "Query", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "SpecialQuery", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "FormQuery", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "Fragment", NULL);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_Uri_WhatWg_UrlHostType(void)
+{
+	zend_class_entry *class_entry = zend_register_internal_enum("Uri\\WhatWg\\UrlHostType", IS_UNDEF, NULL);
+
+	zend_enum_add_case_cstr(class_entry, "IPv4", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "IPv6", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "Domain", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "Opaque", NULL);
+
+	zend_enum_add_case_cstr(class_entry, "Empty", NULL);
 
 	return class_entry;
 }

--- a/ext/uri/php_uri_common.c
+++ b/ext/uri/php_uri_common.c
@@ -19,6 +19,25 @@
 #include "Zend/zend_exceptions.h"
 #include "php_uri_common.h"
 
+zend_class_entry *php_uri_ce_rfc3986_uri;
+zend_class_entry *php_uri_ce_whatwg_url;
+zend_class_entry *php_uri_ce_comparison_mode;
+zend_class_entry *php_uri_ce_exception;
+zend_class_entry *php_uri_ce_error;
+zend_class_entry *php_uri_ce_invalid_uri_exception;
+zend_class_entry *php_uri_ce_rfc3986_uri_query_params;
+zend_class_entry *php_uri_ce_rfc3986_uri_type;
+zend_class_entry *php_uri_ce_rfc3986_uri_host_type;
+zend_class_entry *php_uri_ce_rfc3986_uri_percent_encoding_mode;
+zend_class_entry *php_uri_ce_whatwg_invalid_url_exception;
+zend_class_entry *php_uri_ce_whatwg_url_validation_error_type;
+zend_class_entry *php_uri_ce_whatwg_url_validation_error;
+zend_class_entry *php_uri_ce_whatwg_url_query_params;
+zend_class_entry *php_uri_ce_whatwg_url_host_type;
+zend_class_entry *php_uri_ce_whatwg_url_percent_encoding_mode;
+
+zend_array uri_parsers;
+
 static zend_string *get_known_string_by_property_name(php_uri_property_name property_name)
 {
 	switch (property_name) {
@@ -57,7 +76,7 @@ void php_uri_property_read_helper(INTERNAL_FUNCTION_PARAMETERS, php_uri_property
 	}
 }
 
-static void php_uri_property_write_helper(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name property_name, zval *property_zv)
+void php_uri_property_write_helper(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name property_name, zval *property_zv)
 {
 	php_uri_object *old_uri_object = Z_URI_OBJECT_P(ZEND_THIS);
 	ZEND_ASSERT(old_uri_object->uri != NULL);

--- a/ext/uri/php_uri_common.h
+++ b/ext/uri/php_uri_common.h
@@ -23,9 +23,18 @@ extern zend_class_entry *php_uri_ce_comparison_mode;
 extern zend_class_entry *php_uri_ce_exception;
 extern zend_class_entry *php_uri_ce_error;
 extern zend_class_entry *php_uri_ce_invalid_uri_exception;
+extern zend_class_entry *php_uri_ce_rfc3986_uri_query_params;
+extern zend_class_entry *php_uri_ce_rfc3986_uri_type;
+extern zend_class_entry *php_uri_ce_rfc3986_uri_host_type;
+extern zend_class_entry *php_uri_ce_rfc3986_uri_percent_encoding_mode;
 extern zend_class_entry *php_uri_ce_whatwg_invalid_url_exception;
 extern zend_class_entry *php_uri_ce_whatwg_url_validation_error_type;
 extern zend_class_entry *php_uri_ce_whatwg_url_validation_error;
+extern zend_class_entry *php_uri_ce_whatwg_url_query_params;
+extern zend_class_entry *php_uri_ce_whatwg_url_host_type;
+extern zend_class_entry *php_uri_ce_whatwg_url_percent_encoding_mode;
+
+extern zend_array uri_parsers;
 
 typedef enum php_uri_recomposition_mode {
 	PHP_URI_RECOMPOSITION_MODE_RAW_ASCII,
@@ -160,6 +169,7 @@ PHPAPI zend_object *php_uri_object_handler_clone(zend_object *object);
 #define PHP_URI_PARSER_WHATWG "Uri\\WhatWg\\Url"
 #define PHP_URI_PARSER_PHP_PARSE_URL "parse_url"
 #define PHP_URI_SERIALIZE_URI_FIELD_NAME "uri"
+#define PHP_URI_SERIALIZE_URI_QUERY_PARAM_FIELD_NAME "query"
 
 static inline const php_uri_property_handler *php_uri_parser_property_handler_by_name(const php_uri_parser *parser, php_uri_property_name property_name)
 {
@@ -188,5 +198,6 @@ void php_uri_property_read_helper(INTERNAL_FUNCTION_PARAMETERS, php_uri_property
 void php_uri_property_write_str_helper(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name property_name);
 void php_uri_property_write_str_or_null_helper(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name property_name);
 void php_uri_property_write_long_or_null_helper(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name property_name);
+void php_uri_property_write_helper(INTERNAL_FUNCTION_PARAMETERS, php_uri_property_name property_name, zval *property_zv);
 
 #endif

--- a/ext/uri/php_uri_parser.c
+++ b/ext/uri/php_uri_parser.c
@@ -1,0 +1,1160 @@
+/*
+   +----------------------------------------------------------------------+
+   | Copyright (c) The PHP Group                                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | https://www.php.net/license/3_01.txt                                 |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Authors: Máté Kocsis <kocsismate@php.net>                            |
+   +----------------------------------------------------------------------+
+*/
+
+#include "zend_smart_str.h"
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include "php.h"
+#include "Zend/zend_interfaces.h"
+#include "Zend/zend_exceptions.h"
+#include "Zend/zend_attributes.h"
+#include "Zend/zend_enum.h"
+
+#include "php_uri.h"
+#include "uri_parser_whatwg.h"
+#include "uri_parser_rfc3986.h"
+#include "uriparser/UriBase.h"
+
+PHP_METHOD(Uri_Rfc3986_Uri, percentEncode)
+{
+	zend_string *str;
+	zend_object *mode_object;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(str)
+		Z_PARAM_OBJ_OF_CLASS(mode_object, php_uri_ce_rfc3986_uri_percent_encoding_mode)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zval *case_name = zend_enum_fetch_case_name(mode_object);
+	zend_string *result;
+
+	if (zend_string_equals_literal(Z_STR_P(case_name), "UserInfo")) {
+		result = php_uri_parser_rfc3986_percent_encode_user_info(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "Host")) {
+		result = php_uri_parser_rfc3986_percent_encode_host(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "Path")) {
+		result = php_uri_parser_rfc3986_percent_encode_path(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "PathSegment")) {
+		result = php_uri_parser_rfc3986_percent_encode_path_segment(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "RelativeReferencePath")) {
+		result = php_uri_parser_rfc3986_percent_encode_relative_reference_path(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "RelativeReferenceFirstPathSegment")) {
+		result = php_uri_parser_rfc3986_percent_encode_relative_reference_first_path_segment(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "Query")) {
+		result = php_uri_parser_rfc3986_percent_encode_query_or_fragment(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "FormQuery")) {
+		result = php_uri_parser_rfc3986_percent_encode_query_or_fragment(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "Fragment")) {
+		result = php_uri_parser_rfc3986_percent_encode_query_or_fragment(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "AllReservedCharacters")) {
+		result = php_uri_parser_rfc3986_percent_encode_reserved_characters(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "All")) {
+		result = php_uri_parser_rfc3986_percent_encode_all(str);
+	} else {
+		ZEND_UNREACHABLE();
+	}
+
+	RETVAL_NEW_STR(result);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, percentDecode)
+{
+	zend_string *str;
+	zend_object *mode_object;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(str)
+		Z_PARAM_OBJ_OF_CLASS(mode_object, php_uri_ce_rfc3986_uri_percent_encoding_mode)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zval *case_name = zend_enum_fetch_case_name(mode_object);
+	zend_string *result;
+
+	if (zend_string_equals_literal(Z_STR_P(case_name), "UserInfo")) {
+		result = php_uri_parser_rfc3986_percent_encode_user_info(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "Host")) {
+		result = php_uri_parser_rfc3986_percent_encode_host(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "Path")) {
+		result = php_uri_parser_rfc3986_percent_encode_path(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "PathSegment")) {
+		result = php_uri_parser_rfc3986_percent_encode_path_segment(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "RelativeReferencePath")) {
+		result = php_uri_parser_rfc3986_percent_encode_relative_reference_path(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "RelativeReferenceFirstPathSegment")) {
+		result = php_uri_parser_rfc3986_percent_encode_relative_reference_first_path_segment(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "Query")) {
+		result = php_uri_parser_rfc3986_percent_encode_query_or_fragment(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "FormQuery")) {
+		result = php_uri_parser_rfc3986_percent_encode_query_or_fragment(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "Fragment")) {
+		result = php_uri_parser_rfc3986_percent_encode_query_or_fragment(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "AllReservedCharacters")) {
+		result = php_uri_parser_rfc3986_percent_decode_reserved_characters(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "All")) {
+		result = php_uri_parser_rfc3986_percent_decode(str);
+	} else {
+		ZEND_UNREACHABLE();
+	}
+
+	if (result == NULL) {
+		RETURN_NULL();
+	}
+
+	RETVAL_NEW_STR(result);
+}
+
+/**
+ * Pass the errors parameter by ref to errors_zv for userland, and frees it if
+ * it is not not needed anymore.
+ */
+static zend_result pass_errors_by_ref_and_free(zval *errors_zv, zval *errors)
+{
+	ZEND_ASSERT(Z_TYPE_P(errors) == IS_UNDEF || Z_TYPE_P(errors) == IS_ARRAY);
+
+	/* There was no error during parsing */
+	if (Z_ISUNDEF_P(errors)) {
+		return SUCCESS;
+	}
+
+	/* The errors parameter is an array, but the pass-by ref argument stored by
+	 * errors_zv was not passed - the URI implementation either doesn't support
+	 * returning additional error information, or the caller is not interested in it */
+	if (errors_zv == NULL) {
+		zval_ptr_dtor(errors);
+		return SUCCESS;
+	}
+
+	ZEND_TRY_ASSIGN_REF_TMP(errors_zv, errors);
+	if (EG(exception)) {
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+
+ZEND_ATTRIBUTE_NONNULL_ARGS(1, 2) PHPAPI void php_uri_instantiate_uri(
+		INTERNAL_FUNCTION_PARAMETERS, const zend_string *uri_str, const php_uri_object *base_url_object,
+		bool should_throw, bool should_update_this_object, zval *errors_zv
+) {
+	php_uri_object *uri_object;
+	if (should_update_this_object) {
+		uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+		if (uri_object->uri != NULL) {
+			zend_throw_error(NULL, "Cannot modify readonly object of class %s", ZSTR_VAL(Z_OBJCE_P(ZEND_THIS)->name));
+			RETURN_THROWS();
+		}
+	} else {
+		if (EX(func)->common.fn_flags & ZEND_ACC_STATIC) {
+			object_init_ex(return_value, Z_CE_P(ZEND_THIS));
+		} else {
+			object_init_ex(return_value, Z_OBJCE_P(ZEND_THIS));
+		}
+		uri_object = Z_URI_OBJECT_P(return_value);
+	}
+
+	const php_uri_parser *uri_parser = uri_object->parser;
+
+	zval errors;
+	ZVAL_UNDEF(&errors);
+
+	void *base_url = NULL;
+	if (base_url_object != NULL) {
+		ZEND_ASSERT(base_url_object->std.ce == uri_object->std.ce);
+		ZEND_ASSERT(base_url_object->uri != NULL);
+		ZEND_ASSERT(base_url_object->parser == uri_parser);
+		base_url = base_url_object->uri;
+	}
+
+	void *uri = uri_parser->parse(ZSTR_VAL(uri_str), ZSTR_LEN(uri_str), base_url, errors_zv != NULL ? &errors : NULL, !should_throw);
+	if (UNEXPECTED(uri == NULL)) {
+		if (should_throw) {
+			zval_ptr_dtor(&errors);
+			RETURN_THROWS();
+		} else {
+			if (pass_errors_by_ref_and_free(errors_zv, &errors) == FAILURE) {
+				RETURN_THROWS();
+			}
+			zval_ptr_dtor(return_value);
+			RETURN_NULL();
+		}
+	}
+
+	if (pass_errors_by_ref_and_free(errors_zv, &errors) == FAILURE) {
+		uri_parser->destroy(uri);
+		RETURN_THROWS();
+	}
+
+	uri_object->uri = uri;
+}
+
+static void create_rfc3986_uri(INTERNAL_FUNCTION_PARAMETERS, bool is_constructor)
+{
+	zend_string *uri_str;
+	zend_object *base_url_object = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_STR(uri_str)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_OBJ_OF_CLASS_OR_NULL(base_url_object, php_uri_ce_rfc3986_uri)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_uri_instantiate_uri(INTERNAL_FUNCTION_PARAM_PASSTHRU,
+		uri_str, base_url_object ? php_uri_object_from_obj(base_url_object) : NULL, is_constructor, is_constructor, NULL);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, __construct)
+{
+	create_rfc3986_uri(INTERNAL_FUNCTION_PARAM_PASSTHRU, true);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, parse)
+{
+	create_rfc3986_uri(INTERNAL_FUNCTION_PARAM_PASSTHRU, false);
+}
+
+static bool is_list_of_whatwg_validation_errors(const HashTable *array)
+{
+	if (!zend_array_is_list(array)) {
+		return false;
+	}
+
+	ZEND_HASH_FOREACH_VAL(array, zval *val) {
+		/* Do not allow references as they may change types after checking. */
+
+		if (Z_TYPE_P(val) != IS_OBJECT) {
+			return false;
+		}
+
+		if (!instanceof_function(Z_OBJCE_P(val), php_uri_ce_whatwg_url_validation_error)) {
+			return false;
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	return true;
+}
+
+PHP_METHOD(Uri_WhatWg_InvalidUrlException, __construct)
+{
+	zend_string *message = NULL;
+	zval *errors = NULL;
+	zend_long code = 0;
+	zval *previous = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(0, 4)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_STR(message)
+		Z_PARAM_ARRAY(errors)
+		Z_PARAM_LONG(code)
+		Z_PARAM_OBJECT_OF_CLASS_OR_NULL(previous, zend_ce_throwable)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (zend_update_exception_properties(INTERNAL_FUNCTION_PARAM_PASSTHRU, message, code, previous) == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	if (errors == NULL) {
+		zval tmp;
+		ZVAL_EMPTY_ARRAY(&tmp);
+		zend_update_property(php_uri_ce_whatwg_invalid_url_exception, Z_OBJ_P(ZEND_THIS), ZEND_STRL("errors"), &tmp);
+	} else {
+		if (!is_list_of_whatwg_validation_errors(Z_ARR_P(errors))) {
+			zend_argument_value_error(2, "must be a list of %s", ZSTR_VAL(php_uri_ce_whatwg_url_validation_error->name));
+			RETURN_THROWS();
+		}
+
+		zend_update_property(php_uri_ce_whatwg_invalid_url_exception, Z_OBJ_P(ZEND_THIS), ZEND_STRL("errors"), errors);
+	}
+	if (EG(exception)) {
+		RETURN_THROWS();
+	}
+}
+
+PHP_METHOD(Uri_WhatWg_UrlValidationError, __construct)
+{
+	zend_string *context;
+	zval *type;
+	bool failure;
+
+	ZEND_PARSE_PARAMETERS_START(3, 3)
+		Z_PARAM_STR(context)
+		Z_PARAM_OBJECT_OF_CLASS(type, php_uri_ce_whatwg_url_validation_error_type)
+		Z_PARAM_BOOL(failure)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_update_property_str(php_uri_ce_whatwg_url_validation_error, Z_OBJ_P(ZEND_THIS), ZEND_STRL("context"), context);
+	if (EG(exception)) {
+		RETURN_THROWS();
+	}
+
+	zend_update_property_ex(php_uri_ce_whatwg_url_validation_error, Z_OBJ_P(ZEND_THIS), ZSTR_KNOWN(ZEND_STR_TYPE), type);
+	if (EG(exception)) {
+		RETURN_THROWS();
+	}
+
+	zval failure_zv;
+	ZVAL_BOOL(&failure_zv, failure);
+	zend_update_property(php_uri_ce_whatwg_url_validation_error, Z_OBJ_P(ZEND_THIS), ZEND_STRL("failure"), &failure_zv);
+	if (EG(exception)) {
+		RETURN_THROWS();
+	}
+}
+
+static void create_whatwg_uri(INTERNAL_FUNCTION_PARAMETERS, bool is_constructor)
+{
+	zend_string *uri_str;
+	zend_object *base_url_object = NULL;
+	zval *errors = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(1, 3)
+		Z_PARAM_STR(uri_str)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_OBJ_OF_CLASS_OR_NULL(base_url_object, php_uri_ce_whatwg_url)
+		Z_PARAM_ZVAL(errors)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_uri_instantiate_uri(INTERNAL_FUNCTION_PARAM_PASSTHRU,
+		uri_str, base_url_object ? php_uri_object_from_obj(base_url_object) : NULL, is_constructor, is_constructor, errors);
+}
+
+PHP_METHOD(Uri_WhatWg_Url, __construct)
+{
+	create_whatwg_uri(INTERNAL_FUNCTION_PARAM_PASSTHRU, true);
+}
+
+PHP_METHOD(Uri_WhatWg_Url, parse)
+{
+	create_whatwg_uri(INTERNAL_FUNCTION_PARAM_PASSTHRU, false);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getUriType)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	php_uri_parser_rfc3986_uri_type_read(uri_object->uri, return_value);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getScheme)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_SCHEME, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getRawScheme)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_SCHEME, PHP_URI_COMPONENT_READ_MODE_RAW);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, withScheme)
+{
+	php_uri_property_write_str_or_null_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_SCHEME);
+}
+
+static void rfc3986_userinfo_read(INTERNAL_FUNCTION_PARAMETERS, php_uri_component_read_mode read_mode)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	if (UNEXPECTED(php_uri_parser_rfc3986_userinfo_read(uri_object->uri, read_mode, return_value) == FAILURE)) {
+		zend_throw_error(NULL, "The userinfo component cannot be retrieved");
+		RETURN_THROWS();
+	}
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getUserInfo)
+{
+	rfc3986_userinfo_read(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getRawUserInfo)
+{
+	rfc3986_userinfo_read(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_COMPONENT_READ_MODE_RAW);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, withUserInfo)
+{
+	zend_string *value;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR_OR_NULL(value)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zval zv;
+	if (value == NULL) {
+		ZVAL_NULL(&zv);
+	} else {
+		ZVAL_STR(&zv, value);
+	}
+
+	php_uri_object *old_uri_object = php_uri_object_from_obj(Z_OBJ_P(ZEND_THIS));
+	ZEND_ASSERT(old_uri_object->uri != NULL);
+
+	zend_object *new_object = old_uri_object->std.handlers->clone_obj(&old_uri_object->std);
+	if (new_object == NULL) {
+		RETURN_THROWS();
+	}
+
+	/* Assign the object early. The engine will take care of destruction in
+	 * case of an exception being thrown. */
+	RETVAL_OBJ(new_object);
+
+	php_uri_object *new_uri_object = php_uri_object_from_obj(new_object);
+	ZEND_ASSERT(new_uri_object->uri != NULL);
+
+	if (UNEXPECTED(php_uri_parser_rfc3986_userinfo_write(new_uri_object->uri, &zv, NULL) == FAILURE)) {
+		RETURN_THROWS();
+	}
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getUsername)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_USERNAME, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getRawUsername)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_USERNAME, PHP_URI_COMPONENT_READ_MODE_RAW);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getPassword)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_PASSWORD, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getRawPassword)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_PASSWORD, PHP_URI_COMPONENT_READ_MODE_RAW);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getHost)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_HOST, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getRawHost)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_HOST, PHP_URI_COMPONENT_READ_MODE_RAW);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getHostType)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	php_uri_parser_rfc3986_host_type_read(uri_object->uri, PHP_URI_COMPONENT_READ_MODE_RAW, return_value);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, withHost)
+{
+	php_uri_property_write_str_or_null_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_HOST);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getPort)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_PORT, PHP_URI_COMPONENT_READ_MODE_RAW);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, withPort)
+{
+	php_uri_property_write_long_or_null_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_PORT);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getPath)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_PATH, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getRawPath)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_PATH, PHP_URI_COMPONENT_READ_MODE_RAW);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getPathSegments)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	if (php_uri_parser_rfc3986_path_segments_read(uri_object->uri, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII, return_value) == FAILURE) {
+		zend_throw_exception_ex(php_uri_ce_error, 0, "The path component cannot be retrieved");
+		RETURN_THROWS();
+	}
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getRawPathSegments)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	if (php_uri_parser_rfc3986_path_segments_read(uri_object->uri, PHP_URI_COMPONENT_READ_MODE_RAW, return_value) == FAILURE) {
+		zend_throw_exception_ex(php_uri_ce_error, 0, "The path component cannot be retrieved");
+		RETURN_THROWS();
+	}
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, withPath)
+{
+	php_uri_property_write_str_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_PATH);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, withPathSegments)
+{
+	zval *segments;
+	bool include_leading_slash_for_non_empty_relative_uri = true;
+
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_ARRAY(segments)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_BOOL(include_leading_slash_for_non_empty_relative_uri)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_uri_object *old_uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(old_uri_object->uri != NULL);
+
+	zend_object *new_object = old_uri_object->std.handlers->clone_obj(&old_uri_object->std);
+	if (new_object == NULL) {
+		RETURN_THROWS();
+	}
+
+	/* Assign the object early. The engine will take care of destruction in
+	 * case of an exception being thrown. */
+	RETVAL_OBJ(new_object);
+
+	php_uri_object *new_uri_object = php_uri_object_from_obj(new_object);
+	ZEND_ASSERT(new_uri_object->uri != NULL);
+
+	if (UNEXPECTED(php_uri_parser_rfc3986_path_segments_write(new_uri_object->uri, segments, include_leading_slash_for_non_empty_relative_uri) == FAILURE)) {
+		RETURN_THROWS();
+	}
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getQuery)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_QUERY, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getRawQuery)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_QUERY, PHP_URI_COMPONENT_READ_MODE_RAW);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, withQuery)
+{
+	php_uri_property_write_str_or_null_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_QUERY);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getRawQueryParams)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	if (UNEXPECTED(php_uri_parser_rfc3986_query_params_read(uri_object->uri, PHP_URI_COMPONENT_READ_MODE_RAW, return_value) == FAILURE)) {
+		RETURN_THROWS();
+	}
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getQueryParams)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	if (UNEXPECTED(php_uri_parser_rfc3986_query_params_read(uri_object->uri, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII, return_value) == FAILURE)) {
+		RETURN_THROWS();
+	}
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, withQueryParams)
+{
+	zval *zv;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_OBJECT_OF_CLASS_OR_NULL(zv, php_uri_ce_rfc3986_uri_query_params)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_uri_object *old_uri_object = php_uri_object_from_obj(Z_OBJ_P(ZEND_THIS));
+	ZEND_ASSERT(old_uri_object->uri != NULL);
+
+	zend_object *new_object = old_uri_object->std.handlers->clone_obj(&old_uri_object->std);
+	if (new_object == NULL) {
+		RETURN_THROWS();
+	}
+
+	/* Assign the object early. The engine will take care of destruction in
+	 * case of an exception being thrown. */
+	RETVAL_OBJ(new_object);
+
+	php_uri_object *new_uri_object = php_uri_object_from_obj(new_object);
+	ZEND_ASSERT(new_uri_object->uri != NULL);
+
+	if (UNEXPECTED(php_uri_parser_rfc3986_query_params_write(new_uri_object->uri, zv) == FAILURE)) {
+		RETURN_THROWS();
+	}
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getFragment)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_FRAGMENT, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, getRawFragment)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_FRAGMENT, PHP_URI_COMPONENT_READ_MODE_RAW);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, withFragment)
+{
+	php_uri_property_write_str_or_null_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_FRAGMENT);
+}
+
+static void throw_cannot_recompose_uri_to_string(zend_object *object)
+{
+	zend_throw_exception_ex(php_uri_ce_error, 0, "Cannot recompose %s to a string", ZSTR_VAL(object->ce->name));
+}
+
+static void uri_equals(INTERNAL_FUNCTION_PARAMETERS, php_uri_object *that_object, zend_object *comparison_mode)
+{
+	php_uri_object *this_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(this_object->uri != NULL);
+	ZEND_ASSERT(that_object->uri != NULL);
+
+	if (this_object->std.ce != that_object->std.ce &&
+		!instanceof_function(this_object->std.ce, that_object->std.ce) &&
+		!instanceof_function(that_object->std.ce, this_object->std.ce)
+	) {
+		RETURN_FALSE;
+	}
+
+	bool exclude_fragment = true;
+	if (comparison_mode) {
+		zval *case_name = zend_enum_fetch_case_name(comparison_mode);
+		exclude_fragment = zend_string_equals_literal(Z_STR_P(case_name), "ExcludeFragment");
+	}
+
+	zend_string *this_str = this_object->parser->to_string(
+		this_object->uri, PHP_URI_RECOMPOSITION_MODE_NORMALIZED_ASCII, exclude_fragment);
+	if (this_str == NULL) {
+		throw_cannot_recompose_uri_to_string(&this_object->std);
+		RETURN_THROWS();
+	}
+
+	zend_string *that_str = that_object->parser->to_string(
+		that_object->uri, PHP_URI_RECOMPOSITION_MODE_NORMALIZED_ASCII, exclude_fragment);
+	if (that_str == NULL) {
+		zend_string_release(this_str);
+		throw_cannot_recompose_uri_to_string(&that_object->std);
+		RETURN_THROWS();
+	}
+
+	RETVAL_BOOL(zend_string_equals(this_str, that_str));
+
+	zend_string_release(this_str);
+	zend_string_release(that_str);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, equals)
+{
+	zend_object *that_object;
+	zend_object *comparison_mode = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_OBJ_OF_CLASS(that_object, php_uri_ce_rfc3986_uri)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_OBJ_OF_CLASS(comparison_mode, php_uri_ce_comparison_mode)
+	ZEND_PARSE_PARAMETERS_END();
+
+	uri_equals(INTERNAL_FUNCTION_PARAM_PASSTHRU, php_uri_object_from_obj(that_object), comparison_mode);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, toRawString)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	zend_string *uri_str = uri_object->parser->to_string(uri_object->uri, PHP_URI_RECOMPOSITION_MODE_RAW_ASCII, false);
+	if (uri_str == NULL) {
+		throw_cannot_recompose_uri_to_string(&uri_object->std);
+		RETURN_THROWS();
+	}
+
+	RETURN_STR(uri_str);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, toString)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	zend_string *uri_str = uri_object->parser->to_string(uri_object->uri, PHP_URI_RECOMPOSITION_MODE_NORMALIZED_ASCII, false);
+	if (uri_str == NULL) {
+		throw_cannot_recompose_uri_to_string(&uri_object->std);
+		RETURN_THROWS();
+	}
+
+	RETURN_STR(uri_str);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, resolve)
+{
+	zend_string *uri_str;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(uri_str)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_uri_instantiate_uri(INTERNAL_FUNCTION_PARAM_PASSTHRU,
+		uri_str, Z_URI_OBJECT_P(ZEND_THIS), true, false, NULL);
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, __serialize)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	/* Serialize state: "uri" key in the first array */
+	zend_string *uri_str = uri_object->parser->to_string(uri_object->uri, PHP_URI_RECOMPOSITION_MODE_RAW_ASCII, false);
+	if (uri_str == NULL) {
+		throw_cannot_recompose_uri_to_string(&uri_object->std);
+		RETURN_THROWS();
+	}
+	zval tmp;
+	ZVAL_STR(&tmp, uri_str);
+
+	array_init(return_value);
+
+	zval arr;
+	array_init(&arr);
+	zend_hash_str_add_new(Z_ARRVAL(arr), PHP_URI_SERIALIZE_URI_FIELD_NAME, sizeof(PHP_URI_SERIALIZE_URI_FIELD_NAME) - 1, &tmp);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &arr);
+
+	/* Serialize regular properties: second array */
+	ZVAL_EMPTY_ARRAY(&arr);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &arr);
+}
+
+static void uri_unserialize(INTERNAL_FUNCTION_PARAMETERS)
+{
+	HashTable *data;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_HT(data)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_uri_object *uri_object = php_uri_object_from_obj(Z_OBJ_P(ZEND_THIS));
+	if (uri_object->uri != NULL) {
+		/* Intentionally throw two exceptions for proper chaining. */
+		zend_throw_error(NULL, "Cannot modify readonly object of class %s", ZSTR_VAL(uri_object->std.ce->name));
+		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_object->std.ce->name));
+		RETURN_THROWS();
+	}
+
+	/* Verify the expected number of elements, this implicitly ensures that no additional elements are present. */
+	if (zend_hash_num_elements(data) != 2) {
+		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_object->std.ce->name));
+		RETURN_THROWS();
+	}
+
+	/* Unserialize state: "uri" key in the first array */
+	zval *arr = zend_hash_index_find(data, 0);
+	if (arr == NULL || Z_TYPE_P(arr) != IS_ARRAY) {
+		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_object->std.ce->name));
+		RETURN_THROWS();
+	}
+
+	/* Verify the expected number of elements inside the first array, this implicitly ensures that no additional elements are present. */
+	if (zend_hash_num_elements(Z_ARRVAL_P(arr)) != 1) {
+		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_object->std.ce->name));
+		RETURN_THROWS();
+	}
+
+	zval *uri_zv = zend_hash_str_find(Z_ARRVAL_P(arr), ZEND_STRL(PHP_URI_SERIALIZE_URI_FIELD_NAME));
+	if (uri_zv == NULL || Z_TYPE_P(uri_zv) != IS_STRING) {
+		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_object->std.ce->name));
+		RETURN_THROWS();
+	}
+
+	uri_object->uri = uri_object->parser->parse(Z_STRVAL_P(uri_zv), Z_STRLEN_P(uri_zv), NULL, NULL, true);
+	if (uri_object->uri == NULL) {
+		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_object->std.ce->name));
+		RETURN_THROWS();
+	}
+
+	/* Unserialize regular properties: second array */
+	arr = zend_hash_index_find(data, 1);
+	if (arr == NULL || Z_TYPE_P(arr) != IS_ARRAY) {
+		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_object->std.ce->name));
+		RETURN_THROWS();
+	}
+
+	/* Verify that there is no regular property in the second array, because the URI classes have no properties and they are final. */
+	if (zend_hash_num_elements(Z_ARRVAL_P(arr)) > 0) {
+		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_object->std.ce->name));
+		RETURN_THROWS();
+	}
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, __unserialize)
+{
+	uri_unserialize(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+
+static HashTable *uri_get_debug_properties(php_uri_object *object)
+{
+	const HashTable *std_properties = zend_std_get_properties(&object->std);
+	HashTable *result = zend_array_dup(std_properties);
+
+	const php_uri_parser * const parser = object->parser;
+	void * const uri = object->uri;
+
+	if (UNEXPECTED(uri == NULL)) {
+		return result;
+	}
+
+	zval tmp;
+	if (parser->property_handler.scheme.read(uri, PHP_URI_COMPONENT_READ_MODE_RAW, &tmp) == SUCCESS) {
+		zend_hash_update(result, ZSTR_KNOWN(ZEND_STR_SCHEME), &tmp);
+	}
+
+	if (parser->property_handler.username.read(uri, PHP_URI_COMPONENT_READ_MODE_RAW, &tmp) == SUCCESS) {
+		zend_hash_update(result, ZSTR_KNOWN(ZEND_STR_USERNAME), &tmp);
+	}
+
+	if (parser->property_handler.password.read(uri, PHP_URI_COMPONENT_READ_MODE_RAW, &tmp) == SUCCESS) {
+		zend_hash_update(result, ZSTR_KNOWN(ZEND_STR_PASSWORD), &tmp);
+	}
+
+	if (parser->property_handler.host.read(uri, PHP_URI_COMPONENT_READ_MODE_RAW, &tmp) == SUCCESS) {
+		zend_hash_update(result, ZSTR_KNOWN(ZEND_STR_HOST), &tmp);
+	}
+
+	if (parser->property_handler.port.read(uri, PHP_URI_COMPONENT_READ_MODE_RAW, &tmp) == SUCCESS) {
+		zend_hash_update(result, ZSTR_KNOWN(ZEND_STR_PORT), &tmp);
+	}
+
+	if (parser->property_handler.path.read(uri, PHP_URI_COMPONENT_READ_MODE_RAW, &tmp) == SUCCESS) {
+		zend_hash_update(result, ZSTR_KNOWN(ZEND_STR_PATH), &tmp);
+	}
+
+	if (parser->property_handler.query.read(uri, PHP_URI_COMPONENT_READ_MODE_RAW, &tmp) == SUCCESS) {
+		zend_hash_update(result, ZSTR_KNOWN(ZEND_STR_QUERY), &tmp);
+	}
+
+	if (parser->property_handler.fragment.read(uri, PHP_URI_COMPONENT_READ_MODE_RAW, &tmp) == SUCCESS) {
+		zend_hash_update(result, ZSTR_KNOWN(ZEND_STR_FRAGMENT), &tmp);
+	}
+
+	return result;
+}
+
+PHP_METHOD(Uri_Rfc3986_Uri, __debugInfo)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+
+	RETURN_ARR(uri_get_debug_properties(uri_object));
+}
+
+PHP_METHOD(Uri_WhatWg_Url, percentEncode)
+{
+	zend_string *str;
+	zend_object *mode_object;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(str)
+		Z_PARAM_OBJ_OF_CLASS(mode_object, php_uri_ce_whatwg_url_percent_encoding_mode)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zval *case_name = zend_enum_fetch_case_name(mode_object);
+	zend_string *result;
+
+	if (zend_string_equals_literal(Z_STR_P(case_name), "UserInfo")) {
+		result = php_uri_parser_whatwg_percent_encode_user_info(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "Host")) {
+		result = php_uri_parser_rfc3986_percent_encode_host(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "OpaqueHost")) {
+		result = php_uri_parser_rfc3986_percent_encode_host(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "Path")) {
+		result = php_uri_parser_rfc3986_percent_encode_path(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "OpaquePath")) {
+		result = php_uri_parser_rfc3986_percent_encode_path_segment(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "PathSegment")) {
+		result = php_uri_parser_rfc3986_percent_encode_path_segment(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "OpaquePathSegment")) {
+		result = php_uri_parser_rfc3986_percent_encode_path_segment(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "Query")) {
+		result = php_uri_parser_rfc3986_percent_encode_relative_reference_path(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "SpecialQuery")) {
+		result = php_uri_parser_rfc3986_percent_encode_relative_reference_first_path_segment(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "FormQuery")) {
+		result = php_uri_parser_rfc3986_percent_encode_query_or_fragment(str);
+	} else if (zend_string_equals_literal(Z_STR_P(case_name), "Fragment")) {
+		result = php_uri_parser_rfc3986_percent_encode_query_or_fragment(str);
+	} else {
+		ZEND_UNREACHABLE();
+	}
+
+	RETVAL_NEW_STR(result);
+}
+
+PHP_METHOD(Uri_WhatWg_Url, percentDecode)
+{
+	zend_string *str;
+	zend_object *mode_object;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(str)
+		Z_PARAM_OBJ_OF_CLASS(mode_object, php_uri_ce_whatwg_url_percent_encoding_mode)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+}
+
+PHP_METHOD(Uri_WhatWg_Url, getScheme)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_SCHEME, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
+}
+
+PHP_METHOD(Uri_WhatWg_Url, withScheme)
+{
+	php_uri_property_write_str_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_SCHEME);
+}
+
+PHP_METHOD(Uri_WhatWg_Url, isSpecialScheme)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	RETVAL_BOOL(php_uri_parser_whatwg_is_special(uri_object->uri));
+}
+
+PHP_METHOD(Uri_WhatWg_Url, withUsername)
+{
+	php_uri_property_write_str_or_null_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_USERNAME);
+}
+
+PHP_METHOD(Uri_WhatWg_Url, withPassword)
+{
+	php_uri_property_write_str_or_null_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_PASSWORD);
+}
+
+PHP_METHOD(Uri_WhatWg_Url, getAsciiHost)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_HOST, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_ASCII);
+}
+
+PHP_METHOD(Uri_WhatWg_Url, getUnicodeHost)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_HOST, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_UNICODE);
+}
+
+PHP_METHOD(Uri_WhatWg_Url, getHostType)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	php_uri_parser_whatwg_host_type_read(uri_object->uri, PHP_URI_COMPONENT_READ_MODE_RAW, return_value);
+}
+
+PHP_METHOD(Uri_WhatWg_Url, getPathSegments)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	if (php_uri_parser_whatwg_path_segments_read(uri_object->uri, PHP_URI_COMPONENT_READ_MODE_RAW, return_value) == FAILURE) {
+		zend_throw_exception_ex(php_uri_ce_error, 0, "The path component cannot be retrieved");
+		RETURN_THROWS();
+	}
+}
+
+PHP_METHOD(Uri_WhatWg_Url, withPathSegments)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+}
+
+PHP_METHOD(Uri_WhatWg_Url, getQueryParams)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	if (UNEXPECTED(php_uri_parser_whatwg_query_params_read(uri_object->uri, PHP_URI_COMPONENT_READ_MODE_RAW, return_value) == FAILURE)) {
+		RETURN_THROWS();
+	}
+}
+
+PHP_METHOD(Uri_WhatWg_Url, withQueryParams)
+{
+	zval *zv;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_OBJECT_OF_CLASS_OR_NULL(zv, php_uri_ce_whatwg_url_query_params)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_uri_object *old_uri_object = php_uri_object_from_obj(Z_OBJ_P(ZEND_THIS));
+	ZEND_ASSERT(old_uri_object->uri != NULL);
+
+	zend_object *new_object = old_uri_object->std.handlers->clone_obj(&old_uri_object->std);
+	if (new_object == NULL) {
+		RETURN_THROWS();
+	}
+
+	/* Assign the object early. The engine will take care of destruction in
+	 * case of an exception being thrown. */
+	RETVAL_OBJ(new_object);
+
+	php_uri_object *new_uri_object = php_uri_object_from_obj(new_object);
+	ZEND_ASSERT(new_uri_object->uri != NULL);
+
+	zval errors;
+	ZVAL_UNDEF(&errors);
+
+	if (UNEXPECTED(php_uri_parser_whatwg_query_params_write(new_uri_object->uri, zv, &errors) == FAILURE)) {
+		zval_ptr_dtor(&errors);
+		RETURN_THROWS();
+	}
+
+	ZEND_ASSERT(Z_ISUNDEF(errors));
+}
+
+PHP_METHOD(Uri_WhatWg_Url, getFragment)
+{
+	php_uri_property_read_helper(INTERNAL_FUNCTION_PARAM_PASSTHRU, PHP_URI_PROPERTY_NAME_FRAGMENT, PHP_URI_COMPONENT_READ_MODE_NORMALIZED_UNICODE);
+}
+
+PHP_METHOD(Uri_WhatWg_Url, equals)
+{
+	zend_object *that_object;
+	zend_object *comparison_mode = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_OBJ_OF_CLASS(that_object, php_uri_ce_whatwg_url)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_OBJ_OF_CLASS(comparison_mode, php_uri_ce_comparison_mode)
+	ZEND_PARSE_PARAMETERS_END();
+
+	uri_equals(INTERNAL_FUNCTION_PARAM_PASSTHRU, php_uri_object_from_obj(that_object), comparison_mode);
+}
+
+PHP_METHOD(Uri_WhatWg_Url, toUnicodeString)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	zend_object *this_object = Z_OBJ_P(ZEND_THIS);
+	php_uri_object *uri_object = php_uri_object_from_obj(this_object);
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	RETURN_STR(uri_object->parser->to_string(uri_object->uri, PHP_URI_RECOMPOSITION_MODE_RAW_UNICODE, false));
+}
+
+PHP_METHOD(Uri_WhatWg_Url, toAsciiString)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	zend_object *this_object = Z_OBJ_P(ZEND_THIS);
+	php_uri_object *uri_object = php_uri_object_from_obj(this_object);
+	ZEND_ASSERT(uri_object->uri != NULL);
+
+	RETURN_STR(uri_object->parser->to_string(uri_object->uri, PHP_URI_RECOMPOSITION_MODE_RAW_ASCII, false));
+}
+
+PHP_METHOD(Uri_WhatWg_Url, resolve)
+{
+	zend_string *uri_str;
+	zval *errors = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_STR(uri_str)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_ZVAL(errors)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_uri_instantiate_uri(INTERNAL_FUNCTION_PARAM_PASSTHRU,
+		uri_str, Z_URI_OBJECT_P(ZEND_THIS), true, false, errors);
+}
+
+PHP_METHOD(Uri_WhatWg_Url, __serialize)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *this_object = Z_URI_OBJECT_P(ZEND_THIS);
+	ZEND_ASSERT(this_object->uri != NULL);
+
+	/* Serialize state: "uri" key in the first array */
+	zend_string *uri_str = this_object->parser->to_string(this_object->uri, PHP_URI_RECOMPOSITION_MODE_RAW_ASCII, false);
+	if (uri_str == NULL) {
+		throw_cannot_recompose_uri_to_string(&this_object->std);
+		RETURN_THROWS();
+	}
+	zval tmp;
+	ZVAL_STR(&tmp, uri_str);
+
+	array_init(return_value);
+
+	zval arr;
+	array_init(&arr);
+	zend_hash_str_add_new(Z_ARRVAL(arr), ZEND_STRL(PHP_URI_SERIALIZE_URI_FIELD_NAME), &tmp);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &arr);
+
+	/* Serialize regular properties: second array */
+	ZVAL_EMPTY_ARRAY(&arr);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &arr);
+}
+
+PHP_METHOD(Uri_WhatWg_Url, __unserialize)
+{
+	uri_unserialize(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+
+PHP_METHOD(Uri_WhatWg_Url, __debugInfo)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_object *uri_object = Z_URI_OBJECT_P(ZEND_THIS);
+
+	RETURN_ARR(uri_get_debug_properties(uri_object));
+}

--- a/ext/uri/php_uri_parser.h
+++ b/ext/uri/php_uri_parser.h
@@ -1,0 +1,85 @@
+/*
+   +----------------------------------------------------------------------+
+   | Copyright (c) The PHP Group                                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | https://www.php.net/license/3_01.txt                                 |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Authors: Máté Kocsis <kocsismate@php.net>                            |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef PHP_URI_PARSER_H
+#define PHP_URI_PARSER_H
+
+extern PHP_METHOD(Uri_Rfc3986_Uri, __construct);
+extern PHP_METHOD(Uri_Rfc3986_Uri, parse);
+extern PHP_METHOD(Uri_Rfc3986_Uri, withPassword);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getRawScheme);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getScheme);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getRawUserInfo);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getUserInfo);
+extern PHP_METHOD(Uri_Rfc3986_Uri, withUserInfo);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getRawUsername);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getUsername);
+extern PHP_METHOD(Uri_Rfc3986_Uri, withUsername);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getRawPassword);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getPassword);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getRawHost);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getHost);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getHostType);
+extern PHP_METHOD(Uri_Rfc3986_Uri, withHost);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getPort);
+extern PHP_METHOD(Uri_Rfc3986_Uri, withPort);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getRawPath);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getPath);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getRawPathSegments);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getPathSegments);
+extern PHP_METHOD(Uri_Rfc3986_Uri, withPath);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getRawQuery);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getQuery);
+extern PHP_METHOD(Uri_Rfc3986_Uri, withQuery);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getRawQueryParams);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getQueryParams);
+extern PHP_METHOD(Uri_Rfc3986_Uri, withQueryParams);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getRawFragment);
+extern PHP_METHOD(Uri_Rfc3986_Uri, getFragment);
+extern PHP_METHOD(Uri_Rfc3986_Uri, withFragment);
+extern PHP_METHOD(Uri_Rfc3986_Uri, equals);
+extern PHP_METHOD(Uri_Rfc3986_Uri, toRawString);
+extern PHP_METHOD(Uri_Rfc3986_Uri, toString);
+extern PHP_METHOD(Uri_Rfc3986_Uri, resolve);
+extern PHP_METHOD(Uri_Rfc3986_Uri, __serialize);
+extern PHP_METHOD(Uri_Rfc3986_Uri, __unserialize);
+extern PHP_METHOD(Uri_Rfc3986_Uri, __debugInfo);
+
+extern PHP_METHOD(Uri_WhatWg_InvalidUrlException, withPassword);
+extern PHP_METHOD(Uri_WhatWg_UrlValidationError, withPassword);
+
+extern PHP_METHOD(Uri_WhatWg_Url, __construct);
+extern PHP_METHOD(Uri_WhatWg_Url, parse);
+extern PHP_METHOD(Uri_WhatWg_Url, getScheme);
+extern PHP_METHOD(Uri_WhatWg_Url, withScheme);
+extern PHP_METHOD(Uri_WhatWg_Url, withUsername);
+extern PHP_METHOD(Uri_WhatWg_Url, withPassword);
+extern PHP_METHOD(Uri_WhatWg_Url, getAsciiHost);
+extern PHP_METHOD(Uri_WhatWg_Url, getUnicodeHost);
+extern PHP_METHOD(Uri_WhatWg_Url, getHostType);
+extern PHP_METHOD(Uri_WhatWg_Url, getPathSegments);
+extern PHP_METHOD(Uri_WhatWg_Url, getQueryParams);
+extern PHP_METHOD(Uri_WhatWg_Url, withQueryParams);
+extern PHP_METHOD(Uri_WhatWg_Url, getFragment);
+extern PHP_METHOD(Uri_WhatWg_Url, equals);
+extern PHP_METHOD(Uri_WhatWg_Url, toAsciiString);
+extern PHP_METHOD(Uri_WhatWg_Url, toUnicodeString);
+extern PHP_METHOD(Uri_WhatWg_Url, resolve);
+extern PHP_METHOD(Uri_WhatWg_Url, __serialize);
+extern PHP_METHOD(Uri_WhatWg_Url, __unserialize);
+extern PHP_METHOD(Uri_WhatWg_Url, __debugInfo);
+
+#endif

--- a/ext/uri/php_uri_query.c
+++ b/ext/uri/php_uri_query.c
@@ -1,0 +1,892 @@
+/*
+   +----------------------------------------------------------------------+
+   | Copyright (c) The PHP Group                                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | https://www.php.net/license/3_01.txt                                 |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Authors: Máté Kocsis <kocsismate@php.net>                            |
+   +----------------------------------------------------------------------+
+*/
+
+#include "zend_enum.h"
+#include "zend_smart_str.h"
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include "php.h"
+#include "Zend/zend_exceptions.h"
+
+#include "php_uri_common.h"
+#include "uri_parser_whatwg.h"
+#include "uri_parser_rfc3986.h"
+
+static void throw_cannot_recompose_uri_to_string(zend_object *object)
+{
+	zend_throw_exception_ex(php_uri_ce_error, 0, "Cannot recompose %s to a string", ZSTR_VAL(object->ce->name));
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, parseRfc3986)
+{
+	zend_string *query_str;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(query_str)
+	ZEND_PARSE_PARAMETERS_END();
+
+	object_init_ex(return_value, Z_CE_P(ZEND_THIS));
+	php_uri_parser_rfc3986_uri_query_params_object *uri_query_params_object = Z_URI_QUERY_PARAMS_OBJECT_P(return_value);
+
+	if (php_uri_rfc3986_uri_query_params_from_str(ZSTR_VAL(query_str), ZSTR_LEN(query_str), &uri_query_params_object->query_list, false) == FAILURE) {
+		php_uri_rfc3986_uri_query_params_free(Z_URI_QUERY_PARAMS_OBJECT_P(return_value));
+		RETURN_NULL();
+	}
+
+	uri_query_params_object->is_initialized = true;
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, parseFormData)
+{
+	zend_string *query_str;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(query_str)
+	ZEND_PARSE_PARAMETERS_END();
+
+	object_init_ex(return_value, Z_CE_P(ZEND_THIS));
+	php_uri_parser_rfc3986_uri_query_params_object *uri_query_params_object = Z_URI_QUERY_PARAMS_OBJECT_P(return_value);
+
+	if (php_uri_rfc3986_uri_query_params_from_str(ZSTR_VAL(query_str), ZSTR_LEN(query_str), &uri_query_params_object->query_list, false) == FAILURE) {
+		php_uri_rfc3986_uri_query_params_free(Z_URI_QUERY_PARAMS_OBJECT_P(return_value));
+		RETURN_NULL();
+	}
+
+	uri_query_params_object->is_initialized = true;
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, __construct)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	zval zv;
+	object_init_ex(&zv, Z_CE_P(ZEND_THIS));
+	php_uri_parser_rfc3986_uri_query_params_object *uri_query_params_object = Z_URI_QUERY_PARAMS_OBJECT_P(return_value);
+
+	if (php_uri_rfc3986_uri_query_params_from_str("", 0, &uri_query_params_object->query_list, false) == FAILURE) {
+		php_uri_rfc3986_uri_query_params_free(Z_URI_QUERY_PARAMS_OBJECT_P(&zv));
+	}
+
+	uri_query_params_object->is_initialized = true;
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, fromArray)
+{
+	HashTable *query_params_arr;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_HT(query_params_arr)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+}
+
+static zend_string *php_uri_build_name(const zend_string *name_array_prefix, zend_string *name)
+{
+	if (EXPECTED(name_array_prefix == NULL)) {
+		ZEND_ASSERT(name != NULL);
+
+		return name;
+	}
+
+	smart_str result = {0};
+	smart_str_append(&result, name_array_prefix);
+
+	/* List suffix */
+	if (name == NULL) {
+		smart_str_appendl(&result, "[", strlen("["));
+		smart_str_appendl(&result, "]", strlen("]"));
+
+		return smart_str_extract(&result);
+	}
+
+	smart_str_appendl(&result, "[", strlen("["));
+	smart_str_append(&result, name);
+	smart_str_appendl(&result, "]", strlen("]"));
+
+	return smart_str_extract(&result);
+}
+
+static zend_result uri_query_params_append(php_uri_parser_rfc3986_uri_query_params_object *query_params_object,
+	zend_string *name, const zval *value, const zend_string *name_array_prefix)
+{
+	zend_result result = FAILURE;
+	zend_string *final_name = php_uri_build_name(name_array_prefix, name);
+
+	switch (Z_TYPE_P(value)) {
+		case IS_STRING: {
+			result = php_uri_rfc3986_uri_query_params_append(&query_params_object->query_list,
+				ZSTR_VAL(final_name), ZSTR_LEN(final_name), Z_STRVAL_P(value), Z_STRLEN_P(value)
+			);
+			break;
+		}
+		case IS_FALSE:
+			ZEND_FALLTHROUGH;
+		case IS_TRUE: {
+			zend_string *bool_tmp = zend_string_init(Z_TYPE_P(value) == IS_FALSE ? "0" : "1", 1, false);
+
+			result = php_uri_rfc3986_uri_query_params_append(&query_params_object->query_list,
+				ZSTR_VAL(final_name), ZSTR_LEN(final_name), ZSTR_VAL(bool_tmp), ZSTR_LEN(bool_tmp)
+			);
+
+			zend_string_release_ex(bool_tmp, false);
+			break;
+		}
+		case IS_LONG: {
+			zend_string *long_tmp = zend_long_to_str(Z_LVAL_P(value));
+
+			result = php_uri_rfc3986_uri_query_params_append(&query_params_object->query_list,
+				ZSTR_VAL(final_name), ZSTR_LEN(final_name), ZSTR_VAL(long_tmp), ZSTR_LEN(long_tmp)
+			);
+
+			zend_string_release_ex(long_tmp, false);
+			break;
+		}
+		case IS_DOUBLE: {
+			zend_string *double_tmp = zend_double_to_str(Z_LVAL_P(value));
+
+			result = php_uri_rfc3986_uri_query_params_append(&query_params_object->query_list,
+				ZSTR_VAL(final_name), ZSTR_LEN(final_name), ZSTR_VAL(double_tmp), ZSTR_LEN(double_tmp)
+			);
+
+			zend_string_release_ex(double_tmp, false);
+			break;
+		}
+		case IS_NULL: {
+			result = php_uri_rfc3986_uri_query_params_append(&query_params_object->query_list,
+			ZSTR_VAL(final_name), ZSTR_LEN(final_name), NULL, 0
+			);
+			break;
+		}
+		case IS_RESOURCE:
+			zend_argument_value_error(2, "must not contain a resource");
+			break;
+		case IS_ARRAY: {
+			if (zend_array_count(Z_ARR_P(value)) == 0) {
+				result = php_uri_rfc3986_uri_query_params_append(&query_params_object->query_list,
+				ZSTR_VAL(final_name), ZSTR_LEN(final_name), NULL, 0
+				);
+				break;
+			}
+
+			zend_string *key;
+			zval *data;
+			zend_ulong index;
+
+			if (zend_array_is_list(Z_ARR_P(value))) {
+				ZEND_HASH_FOREACH_VAL(Z_ARR_P(value), data) {
+					result = uri_query_params_append(query_params_object, NULL, data, final_name);
+					if (result == FAILURE) {
+						return FAILURE;
+					}
+				} ZEND_HASH_FOREACH_END();
+			} else {
+				ZEND_HASH_FOREACH_KEY_VAL(Z_ARR_P(value), index, key, data) {
+					if (key == NULL) {
+						key = zend_ulong_to_str(index);
+					}
+
+					result = uri_query_params_append(query_params_object, key, data, final_name);
+					if (result == FAILURE) {
+						return FAILURE;
+					}
+				} ZEND_HASH_FOREACH_END();
+			}
+			break;
+		}
+		case IS_OBJECT:
+			if (Z_OBJCE_P(value)->ce_flags & ZEND_ACC_ENUM && Z_OBJCE_P(value)->enum_backing_type != IS_UNDEF) {
+				result = uri_query_params_append(query_params_object, final_name, zend_enum_fetch_case_value(Z_OBJ_P(value)), NULL);
+			} else {
+				zend_argument_value_error(2, "must not contain an object");
+				break;
+			}
+
+			break;
+	}
+
+	zend_string_release(final_name);
+
+	return result;
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, append)
+{
+	zend_string *name;
+	zval *value;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(name)
+		Z_PARAM_ZVAL(value)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_uri_parser_rfc3986_uri_query_params_object *uri_query_params_object = Z_URI_QUERY_PARAMS_OBJECT_P(ZEND_THIS);
+
+	if (uri_query_params_append(uri_query_params_object, name, value, NULL) == FAILURE) {
+		throw_cannot_recompose_uri_to_string(Z_OBJ_P(ZEND_THIS));
+		RETURN_THROWS();
+	}
+
+	RETVAL_COPY(ZEND_THIS);
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, delete)
+{
+	zend_string *name;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(name)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+	RETVAL_COPY(ZEND_THIS);
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, deleteValue)
+{
+	zend_string *name;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(name)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+	RETVAL_COPY(ZEND_THIS);
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, has)
+{
+	zend_string *name;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(name)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, hasValue)
+{
+	zend_string *name;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(name)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, getFirst)
+{
+	zend_string *name;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(name)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, getLast)
+{
+	zend_string *name;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(name)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, getAll)
+{
+	zend_string *name = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_STR_OR_NULL(name)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, count)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, set)
+{
+	zend_string *name;
+	zval *value;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(name)
+		Z_PARAM_ZVAL(value)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+	RETVAL_COPY(ZEND_THIS);
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, sort)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+	RETVAL_COPY(ZEND_THIS);
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, toRfc3986String)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	const php_uri_parser_rfc3986_uri_query_params_object *uri_query_params_object = Z_URI_QUERY_PARAMS_OBJECT_P(ZEND_THIS);
+
+	zend_string *result = php_uri_rfc3986_uri_query_params_to_string(uri_query_params_object->query_list);
+	if (result == NULL) {
+		throw_cannot_recompose_uri_to_string(Z_OBJ_P(ZEND_THIS));
+		RETURN_THROWS();
+	}
+
+	ZVAL_STR(return_value, result);
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, toFormDataString)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	const php_uri_parser_rfc3986_uri_query_params_object *uri_query_params_object = Z_URI_QUERY_PARAMS_OBJECT_P(ZEND_THIS);
+
+	zend_string *result = php_uri_rfc3986_uri_query_params_to_string(uri_query_params_object->query_list);
+	if (result == NULL) {
+		throw_cannot_recompose_uri_to_string(Z_OBJ_P(ZEND_THIS));
+		RETURN_THROWS();
+	}
+
+	ZVAL_STR(return_value, result);
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, __serialize)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_parser_rfc3986_uri_query_params_object *uri_query_params_object = Z_URI_QUERY_PARAMS_OBJECT_P(ZEND_THIS);
+
+	/* Serialize state: "query" key in the first array */
+	zend_string *uri_query_param_str = php_uri_rfc3986_uri_query_params_to_string(uri_query_params_object->query_list);
+	if (uri_query_param_str == NULL) {
+		throw_cannot_recompose_uri_to_string(Z_OBJ_P(ZEND_THIS));
+		RETURN_THROWS();
+	}
+	zval tmp;
+	ZVAL_STR(&tmp, uri_query_param_str);
+
+	array_init(return_value);
+
+	zval arr;
+	array_init(&arr);
+	zend_hash_str_add_new(Z_ARRVAL(arr), PHP_URI_SERIALIZE_URI_QUERY_PARAM_FIELD_NAME, sizeof(PHP_URI_SERIALIZE_URI_QUERY_PARAM_FIELD_NAME) - 1, &tmp);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &arr);
+
+	/* Serialize regular properties: second array */
+	ZVAL_ARR(&arr, uri_query_params_object->std.handlers->get_properties(&uri_query_params_object->std));
+	Z_TRY_ADDREF(arr);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &arr);
+}
+
+static void uri_query_params_unserialize(INTERNAL_FUNCTION_PARAMETERS)
+{
+	HashTable *data;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_HT(data)
+	ZEND_PARSE_PARAMETERS_END();
+
+	php_uri_parser_rfc3986_uri_query_params_object *uri_query_params_object = Z_URI_QUERY_PARAMS_OBJECT_P(ZEND_THIS);
+	if (uri_query_params_object->query_list != NULL) {
+		/* Intentionally throw two exceptions for proper chaining. */
+		zend_throw_error(NULL, "Cannot modify readonly object of class %s", ZSTR_VAL(uri_query_params_object->std.ce->name));
+		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_query_params_object->std.ce->name));
+		RETURN_THROWS();
+	}
+
+	/* Verify the expected number of elements, this implicitly ensures that no additional elements are present. */
+	if (zend_hash_num_elements(data) != 2) {
+		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_query_params_object->std.ce->name));
+		RETURN_THROWS();
+	}
+
+	/* Unserialize state: "query" key in the first array */
+	zval *arr = zend_hash_index_find(data, 0);
+	if (arr == NULL || Z_TYPE_P(arr) != IS_ARRAY) {
+		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_query_params_object->std.ce->name));
+		RETURN_THROWS();
+	}
+
+	/* Verify the expected number of elements inside the first array, this implicitly ensures that no additional elements are present. */
+	if (zend_hash_num_elements(Z_ARRVAL_P(arr)) != 1) {
+		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_query_params_object->std.ce->name));
+		RETURN_THROWS();
+	}
+
+	const zval *uri_query_param_zv = zend_hash_str_find_ind(Z_ARRVAL_P(arr), ZEND_STRL(PHP_URI_SERIALIZE_URI_QUERY_PARAM_FIELD_NAME));
+	if (uri_query_param_zv == NULL || Z_TYPE_P(uri_query_param_zv) != IS_STRING) {
+		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_query_params_object->std.ce->name));
+		RETURN_THROWS();
+	}
+
+	const zend_result result = php_uri_rfc3986_uri_query_params_from_str(
+		Z_STRVAL_P(uri_query_param_zv),
+		Z_STRLEN_P(uri_query_param_zv),
+		&uri_query_params_object->query_list,
+		false
+	);
+
+	if (result == FAILURE) {
+		RETURN_THROWS();
+	}
+
+	uri_query_params_object->is_initialized = true;
+
+	/* Unserialize regular properties: second array */
+	arr = zend_hash_index_find(data, 1);
+	if (arr == NULL || Z_TYPE_P(arr) != IS_ARRAY) {
+		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_query_params_object->std.ce->name));
+		RETURN_THROWS();
+	}
+
+	/* Verify that there is no regular property in the second array, because the query param classes have no properties and they are final. */
+	if (zend_hash_num_elements(Z_ARRVAL_P(arr)) > 0) {
+		zend_throw_exception_ex(NULL, 0, "Invalid serialization data for %s object", ZSTR_VAL(uri_query_params_object->std.ce->name));
+		RETURN_THROWS();
+	}
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, __unserialize)
+{
+	uri_query_params_unserialize(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+
+PHP_METHOD(Uri_Rfc3986_UriQueryParams, __debugInfo)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_parser_rfc3986_uri_query_params_object *uri_query_params_object = Z_URI_QUERY_PARAMS_OBJECT_P(ZEND_THIS);
+
+	RETURN_ARR(php_uri_rfc3986_uri_query_params_get_debug_properties(uri_query_params_object));
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, parse)
+{
+	zend_string *query_str;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(query_str)
+	ZEND_PARSE_PARAMETERS_END();
+
+	object_init_ex(return_value, Z_CE_P(ZEND_THIS));
+	php_uri_parser_whatwg_url_query_params_object *url_query_params_object = Z_URL_QUERY_PARAMS_OBJECT_P(return_value);
+
+	url_query_params_object->query_params = php_uri_whatwg_url_query_params_from_str(
+		ZSTR_VAL(query_str),
+		ZSTR_LEN(query_str),
+		true
+	);
+
+	if (url_query_params_object->query_params == NULL) {
+		RETURN_NULL();
+	}
+
+	url_query_params_object->is_initialized = true;
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, __construct)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	zval zv;
+	object_init_ex(&zv, Z_CE_P(ZEND_THIS));
+	php_uri_parser_whatwg_url_query_params_object *url_query_params_object = Z_URL_QUERY_PARAMS_OBJECT_P(&zv);
+
+	url_query_params_object->query_params = php_uri_whatwg_url_query_params_from_str(
+		"",
+		0,
+		true
+	);
+
+	if (url_query_params_object->query_params == NULL) {
+		return;
+	}
+
+	url_query_params_object->is_initialized = true;
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, fromArray)
+{
+	HashTable *query_params_arr;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_HT(query_params_arr)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+}
+
+static zend_result php_uri_whatwg_query_params_append(const php_uri_parser_whatwg_url_query_params_object *query_params_object,
+	zend_string *name, const zval *value, const zend_string *name_array_prefix)
+{
+	zend_result result = FAILURE;
+	const zend_string *tmp;
+	zend_string *final_name = php_uri_build_name(name_array_prefix, name);
+
+	switch (Z_TYPE_P(value)) {
+		case IS_STRING:
+			result = php_uri_whatwg_url_query_params_append(query_params_object->query_params,
+			ZSTR_VAL(final_name), ZSTR_LEN(final_name), Z_STRVAL_P(value), Z_STRLEN_P(value)
+			);
+			break;
+		case IS_FALSE:
+			ZEND_FALLTHROUGH;
+		case IS_TRUE: {
+			zend_string *bool_tmp = zend_string_init(Z_TYPE_P(value) == IS_FALSE ? "0" : "1", 1, false);
+			result = php_uri_whatwg_url_query_params_append(query_params_object->query_params,
+			ZSTR_VAL(final_name), ZSTR_LEN(final_name), ZSTR_VAL(bool_tmp), ZSTR_LEN(bool_tmp)
+			);
+			zend_string_release_ex(bool_tmp, false);
+			break;
+		}
+		case IS_LONG: {
+			zend_string *long_tmp = zend_long_to_str(Z_LVAL_P(value));
+			result = php_uri_whatwg_url_query_params_append(query_params_object->query_params,
+			ZSTR_VAL(final_name), ZSTR_LEN(final_name), ZSTR_VAL(long_tmp), ZSTR_LEN(long_tmp)
+			);
+			zend_string_release_ex(long_tmp, false);
+			break;
+		}
+		case IS_DOUBLE: {
+			zend_string *double_tmp = zend_double_to_str(Z_LVAL_P(value));
+			result = php_uri_whatwg_url_query_params_append(query_params_object->query_params,
+			ZSTR_VAL(final_name), ZSTR_LEN(final_name), ZSTR_VAL(double_tmp), ZSTR_LEN(double_tmp)
+			);
+			zend_string_release_ex(double_tmp, false);
+			break;
+		}
+		case IS_NULL:
+			tmp = zend_empty_string;
+
+			result = php_uri_whatwg_url_query_params_append(query_params_object->query_params,
+			ZSTR_VAL(final_name), ZSTR_LEN(final_name), ZSTR_VAL(tmp), ZSTR_LEN(tmp)
+			);
+			break;
+		case IS_RESOURCE:
+			zend_argument_value_error(2, "must not contain a resource");
+			break;
+		case IS_ARRAY: {
+			zend_string *key;
+			zval *data;
+			zend_ulong index;
+
+			if (zend_array_count(Z_ARR_P(value)) == 0) {
+				// TODO what to do here?
+				result = php_uri_whatwg_url_query_params_append(query_params_object->query_params,
+			ZSTR_VAL(final_name), ZSTR_LEN(final_name), "", 0
+				);
+				break;
+			}
+
+			if (zend_array_is_list(Z_ARR_P(value))) {
+				ZEND_HASH_FOREACH_VAL(Z_ARR_P(value), data) {
+					result = php_uri_whatwg_query_params_append(query_params_object, NULL, data, final_name);
+					if (result == FAILURE) {
+						return FAILURE;
+					}
+				} ZEND_HASH_FOREACH_END();
+			} else {
+				ZEND_HASH_FOREACH_KEY_VAL(Z_ARR_P(value), index, key, data) {
+					if (key == NULL) {
+						key = zend_ulong_to_str(index);
+					}
+
+					result = php_uri_whatwg_query_params_append(query_params_object, key, data, final_name);
+					if (result == FAILURE) {
+						return FAILURE;
+					}
+				} ZEND_HASH_FOREACH_END();
+			}
+			break;
+		}
+		case IS_OBJECT:
+			if (Z_OBJCE_P(value)->ce_flags & ZEND_ACC_ENUM && Z_OBJCE_P(value)->enum_backing_type != IS_UNDEF) {
+				result = php_uri_whatwg_query_params_append(query_params_object, final_name, zend_enum_fetch_case_value(Z_OBJ_P(value)), NULL);
+			} else {
+				zend_argument_value_error(2, "must not contain an object");
+			}
+
+			break;
+	}
+
+	zend_string_release(final_name);
+
+	return result;
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, append)
+{
+	zend_string *name;
+	zval *value;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(name)
+		Z_PARAM_ZVAL(value)
+	ZEND_PARSE_PARAMETERS_END();
+
+	const php_uri_parser_whatwg_url_query_params_object *uri_query_params_object = Z_URL_QUERY_PARAMS_OBJECT_P(ZEND_THIS);
+
+	if (php_uri_whatwg_query_params_append(uri_query_params_object, name, value, NULL) == FAILURE) {
+		throw_cannot_recompose_uri_to_string(Z_OBJ_P(ZEND_THIS));
+		RETURN_THROWS();
+	}
+
+	RETVAL_COPY(ZEND_THIS);
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, delete)
+{
+	zend_string *name;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(name)
+	ZEND_PARSE_PARAMETERS_END();
+
+	const php_uri_parser_whatwg_url_query_params_object *uri_query_params_object = Z_URL_QUERY_PARAMS_OBJECT_P(ZEND_THIS);
+
+	php_uri_whatwg_url_query_params_delete(uri_query_params_object->query_params, ZSTR_VAL(name), ZSTR_LEN(name), NULL, 0);
+
+	RETVAL_COPY(ZEND_THIS);
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, deleteValue)
+{
+	zend_string *name, *value;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(name)
+		Z_PARAM_STR(value)
+	ZEND_PARSE_PARAMETERS_END();
+
+	const php_uri_parser_whatwg_url_query_params_object *uri_query_params_object = Z_URL_QUERY_PARAMS_OBJECT_P(ZEND_THIS);
+
+	php_uri_whatwg_url_query_params_delete(uri_query_params_object->query_params,
+		ZSTR_VAL(name), ZSTR_LEN(name), ZSTR_VAL(value), ZSTR_LEN(value)
+	);
+
+	RETVAL_COPY(ZEND_THIS);
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, has)
+{
+	zend_string *name;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(name)
+	ZEND_PARSE_PARAMETERS_END();
+
+	const php_uri_parser_whatwg_url_query_params_object *uri_query_params_object = Z_URL_QUERY_PARAMS_OBJECT_P(ZEND_THIS);
+
+	RETURN_BOOL(php_uri_whatwg_url_query_params_exists(uri_query_params_object->query_params,
+		ZSTR_VAL(name), ZSTR_LEN(name), NULL, 0
+	));
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, hasValue)
+{
+	zend_string *name, *value;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(name)
+		Z_PARAM_STR(value)
+	ZEND_PARSE_PARAMETERS_END();
+
+	const php_uri_parser_whatwg_url_query_params_object *uri_query_params_object = Z_URL_QUERY_PARAMS_OBJECT_P(ZEND_THIS);
+
+	RETURN_BOOL(php_uri_whatwg_url_query_params_exists(uri_query_params_object->query_params,
+		ZSTR_VAL(name), ZSTR_LEN(name), ZSTR_VAL(value), ZSTR_LEN(value)
+	));
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, getFirst)
+{
+	zend_string *name;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(name)
+	ZEND_PARSE_PARAMETERS_END();
+
+	const php_uri_parser_whatwg_url_query_params_object *uri_query_params_object = Z_URL_QUERY_PARAMS_OBJECT_P(ZEND_THIS);
+
+	zend_string *result = php_uri_whatwg_url_query_params_get_first(uri_query_params_object->query_params, ZSTR_VAL(name), ZSTR_LEN(name));
+	if (result == NULL) {
+		RETURN_NULL();
+	}
+
+	RETVAL_STR(result);
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, getLast)
+{
+	zend_string *name;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(name)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, getAll)
+{
+	zend_string *name = NULL;
+
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_STR_OR_NULL(name)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, count)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, set)
+{
+	zend_string *name;
+	zval *value;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(name)
+		Z_PARAM_ZVAL(value)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+	RETVAL_COPY(ZEND_THIS);
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, sort)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+	RETVAL_COPY(ZEND_THIS);
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, toString)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	const php_uri_parser_whatwg_url_query_params_object *uri_query_params_object = Z_URL_QUERY_PARAMS_OBJECT_P(ZEND_THIS);
+
+	zend_string *result = php_uri_whatwg_url_query_params_to_string(uri_query_params_object->query_params);
+	if (result == NULL) {
+		throw_cannot_recompose_uri_to_string(Z_OBJ_P(ZEND_THIS));
+		RETURN_THROWS();
+	}
+
+	ZVAL_STR(return_value, result);
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, __serialize)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_parser_whatwg_url_query_params_object *uri_query_params_object = Z_URL_QUERY_PARAMS_OBJECT_P(ZEND_THIS);
+
+	/* Serialize state: "query" key in the first array */
+	zend_string *url_query_param_str = php_uri_whatwg_url_query_params_to_string(uri_query_params_object->query_params);
+	if (url_query_param_str == NULL) {
+		throw_cannot_recompose_uri_to_string(Z_OBJ_P(ZEND_THIS));
+		RETURN_THROWS();
+	}
+	zval tmp;
+	ZVAL_STR(&tmp, url_query_param_str);
+
+	array_init(return_value);
+
+	zval arr;
+	array_init(&arr);
+	zend_hash_str_add_new(Z_ARRVAL(arr), PHP_URI_SERIALIZE_URI_QUERY_PARAM_FIELD_NAME, sizeof(PHP_URI_SERIALIZE_URI_QUERY_PARAM_FIELD_NAME) - 1, &tmp);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &arr);
+
+	/* Serialize regular properties: second array */
+	ZVAL_ARR(&arr, uri_query_params_object->std.handlers->get_properties(&uri_query_params_object->std));
+	Z_TRY_ADDREF(arr);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &arr);
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, __unserialize)
+{
+	HashTable *data;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_ARRAY_HT(data)
+	ZEND_PARSE_PARAMETERS_END();
+
+	zend_throw_exception(NULL, "Not implemented", 0);
+}
+
+PHP_METHOD(Uri_WhatWg_UrlQueryParams, __debugInfo)
+{
+	ZEND_PARSE_PARAMETERS_NONE();
+
+	php_uri_parser_whatwg_url_query_params_object *url_query_params_object = Z_URL_QUERY_PARAMS_OBJECT_P(ZEND_THIS);
+
+	RETURN_ARR(php_uri_whatwg_url_query_params_get_debug_properties(url_query_params_object));
+}
+
+zend_object *php_uri_object_create_rfc3986_uri_query_params(zend_class_entry *ce)
+{
+	php_uri_parser_rfc3986_uri_query_params_object *uri_query_params_object = zend_object_alloc(sizeof(*php_uri_ce_rfc3986_uri_query_params), ce);
+
+	zend_object_std_init(&uri_query_params_object->std, ce);
+	object_properties_init(&uri_query_params_object->std, ce);
+
+	uri_query_params_object->query_list = NULL;
+	uri_query_params_object->is_initialized = false;
+
+	return &uri_query_params_object->std;
+}
+
+zend_object *php_uri_object_create_whatwg_url_query_params(zend_class_entry *ce)
+{
+	php_uri_parser_whatwg_url_query_params_object *url_query_params_object = zend_object_alloc(sizeof(*url_query_params_object), ce);
+
+	zend_object_std_init(&url_query_params_object->std, ce);
+	object_properties_init(&url_query_params_object->std, ce);
+
+	url_query_params_object->query_params = NULL;
+	url_query_params_object->is_initialized = false;
+
+	return &url_query_params_object->std;
+}

--- a/ext/uri/php_uri_query.h
+++ b/ext/uri/php_uri_query.h
@@ -1,0 +1,52 @@
+/*
+   +----------------------------------------------------------------------+
+   | Copyright (c) The PHP Group                                          |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 3.01 of the PHP license,      |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available through the world-wide-web at the following url:           |
+   | https://www.php.net/license/3_01.txt                                 |
+   | If you did not receive a copy of the PHP license and are unable to   |
+   | obtain it through the world-wide-web, please send a note to          |
+   | license@php.net so we can mail you a copy immediately.               |
+   +----------------------------------------------------------------------+
+   | Authors: Máté Kocsis <kocsismate@php.net>                            |
+   +----------------------------------------------------------------------+
+*/
+
+#ifndef PHP_URI_QUERY_H
+#define PHP_URI_QUERY_H
+
+extern PHP_METHOD(Uri_Rfc3986_UriQueryParams, fromQueryString);
+extern PHP_METHOD(Uri_Rfc3986_UriQueryParams, fromArray);
+extern PHP_METHOD(Uri_Rfc3986_UriQueryParams, append);
+extern PHP_METHOD(Uri_Rfc3986_UriQueryParams, delete);
+extern PHP_METHOD(Uri_Rfc3986_UriQueryParams, has);
+extern PHP_METHOD(Uri_Rfc3986_UriQueryParams, getFirst);
+extern PHP_METHOD(Uri_Rfc3986_UriQueryParams, getLast);
+extern PHP_METHOD(Uri_Rfc3986_UriQueryParams, getAll);
+extern PHP_METHOD(Uri_Rfc3986_UriQueryParams, set);
+extern PHP_METHOD(Uri_Rfc3986_UriQueryParams, sort);
+extern PHP_METHOD(Uri_Rfc3986_UriQueryParams, toString);
+extern PHP_METHOD(Uri_Rfc3986_UriQueryParams, __serialize);
+extern PHP_METHOD(Uri_Rfc3986_UriQueryParams, __unserialize);
+extern PHP_METHOD(Uri_Rfc3986_UriQueryParams, __debugInfo);
+
+extern PHP_METHOD(Uri_WhatWg_UrlQueryParams, fromQueryString);
+extern PHP_METHOD(Uri_WhatWg_UrlQueryParams, fromArray);
+extern PHP_METHOD(Uri_WhatWg_UrlQueryParams, append);
+extern PHP_METHOD(Uri_WhatWg_UrlQueryParams, delete);
+extern PHP_METHOD(Uri_WhatWg_UrlQueryParams, has);
+extern PHP_METHOD(Uri_WhatWg_UrlQueryParams, getFirst);
+extern PHP_METHOD(Uri_WhatWg_UrlQueryParams, getLast);
+extern PHP_METHOD(Uri_WhatWg_UrlQueryParams, getAll);
+extern PHP_METHOD(Uri_WhatWg_UrlQueryParams, set);
+extern PHP_METHOD(Uri_WhatWg_UrlQueryParams, sort);
+extern PHP_METHOD(Uri_WhatWg_UrlQueryParams, toString);
+extern PHP_METHOD(Uri_WhatWg_UrlQueryParams, __serialize);
+extern PHP_METHOD(Uri_WhatWg_UrlQueryParams, __unserialize);
+extern PHP_METHOD(Uri_WhatWg_UrlQueryParams, __debugInfo);
+
+zend_object *php_uri_object_create_rfc3986_uri_query_params(zend_class_entry *ce);
+
+#endif

--- a/ext/uri/tests/rfc3986/getters/host_type_success_ip_future.phpt
+++ b/ext/uri/tests/rfc3986/getters/host_type_success_ip_future.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - host type - IP future
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://[vF.addr]");
+
+var_dump($uri->getHostType());
+
+?>
+--EXPECT--
+enum(Uri\Rfc3986\UriHostType::IPvFuture)

--- a/ext/uri/tests/rfc3986/getters/host_type_success_ipv4.phpt
+++ b/ext/uri/tests/rfc3986/getters/host_type_success_ipv4.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - host type - IPv4
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://192.168.0.1");
+
+var_dump($uri->getHostType());
+
+?>
+--EXPECT--
+enum(Uri\Rfc3986\UriHostType::IPv4)

--- a/ext/uri/tests/rfc3986/getters/host_type_success_ipv6.phpt
+++ b/ext/uri/tests/rfc3986/getters/host_type_success_ipv6.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - host type - IPv6
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://[2001:0db8:3333:4444:5555:6666:7777:8888]");
+
+var_dump($uri->getHostType());
+
+?>
+--EXPECT--
+enum(Uri\Rfc3986\UriHostType::IPv6)

--- a/ext/uri/tests/rfc3986/getters/host_type_success_none.phpt
+++ b/ext/uri/tests/rfc3986/getters/host_type_success_none.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - host type - registered name
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("/foo/bar");
+
+var_dump($uri->getHostType());
+
+?>
+--EXPECT--
+NULL

--- a/ext/uri/tests/rfc3986/getters/host_type_success_registered_name.phpt
+++ b/ext/uri/tests/rfc3986/getters/host_type_success_registered_name.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - host type - registered name
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://example.com");
+
+var_dump($uri->getHostType());
+
+?>
+--EXPECT--
+enum(Uri\Rfc3986\UriHostType::RegisteredName)

--- a/ext/uri/tests/rfc3986/getters/path_segments_success_empty_trailing_uri.phpt
+++ b/ext/uri/tests/rfc3986/getters/path_segments_success_empty_trailing_uri.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - path segments - URI with an empty trailing segment
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://example.com/foo/");
+
+var_dump($uri->getRawPathSegments());
+var_dump($uri->getPathSegments());
+
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(0) ""
+}
+array(2) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(0) ""
+}

--- a/ext/uri/tests/rfc3986/getters/path_segments_success_multiple_path_reference.phpt
+++ b/ext/uri/tests/rfc3986/getters/path_segments_success_multiple_path_reference.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - path segments - path reference with multiple segments
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("/foo/bar/baz");
+
+var_dump($uri->getRawPathSegments());
+var_dump($uri->getPathSegments());
+
+?>
+--EXPECT--
+array(3) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "bar"
+  [2]=>
+  string(3) "baz"
+}
+array(3) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "bar"
+  [2]=>
+  string(3) "baz"
+}

--- a/ext/uri/tests/rfc3986/getters/path_segments_success_multiple_uri.phpt
+++ b/ext/uri/tests/rfc3986/getters/path_segments_success_multiple_uri.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - path segments - URI with multiple segments
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://example.com/foo/bar/baz");
+
+var_dump($uri->getRawPathSegments());
+var_dump($uri->getPathSegments());
+
+?>
+--EXPECT--
+array(3) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "bar"
+  [2]=>
+  string(3) "baz"
+}
+array(3) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "bar"
+  [2]=>
+  string(3) "baz"
+}

--- a/ext/uri/tests/rfc3986/getters/path_segments_success_one_absolute_path_reference.phpt
+++ b/ext/uri/tests/rfc3986/getters/path_segments_success_one_absolute_path_reference.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - path segments - absolute path reference with one non-empty segment
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("/foo");
+
+var_dump($uri->getRawPathSegments());
+var_dump($uri->getPathSegments());
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  string(3) "foo"
+}
+array(1) {
+  [0]=>
+  string(3) "foo"
+}

--- a/ext/uri/tests/rfc3986/getters/path_segments_success_one_empty_path_reference.phpt
+++ b/ext/uri/tests/rfc3986/getters/path_segments_success_one_empty_path_reference.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - path segments - path reference with one empty segment
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("/");
+
+var_dump($uri->getRawPathSegments());
+var_dump($uri->getPathSegments());
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  string(0) ""
+}
+array(1) {
+  [0]=>
+  string(0) ""
+}

--- a/ext/uri/tests/rfc3986/getters/path_segments_success_one_empty_uri.phpt
+++ b/ext/uri/tests/rfc3986/getters/path_segments_success_one_empty_uri.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - path segments - URI with one empty segment
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://example.com/");
+
+var_dump($uri->getRawPathSegments());
+var_dump($uri->getPathSegments());
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  string(0) ""
+}
+array(1) {
+  [0]=>
+  string(0) ""
+}

--- a/ext/uri/tests/rfc3986/getters/path_segments_success_one_empty_uri_no_authority.phpt
+++ b/ext/uri/tests/rfc3986/getters/path_segments_success_one_empty_uri_no_authority.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - path segments - URI without authority with one empty segment
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https:/");
+
+var_dump($uri->getRawPathSegments());
+var_dump($uri->getPathSegments());
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  string(0) ""
+}
+array(1) {
+  [0]=>
+  string(0) ""
+}

--- a/ext/uri/tests/rfc3986/getters/path_segments_success_one_relative_path_reference.phpt
+++ b/ext/uri/tests/rfc3986/getters/path_segments_success_one_relative_path_reference.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - path segments - relative path reference with one non-empty segment
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("foo");
+
+var_dump($uri->getRawPathSegments());
+var_dump($uri->getPathSegments());
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  string(3) "foo"
+}
+array(1) {
+  [0]=>
+  string(3) "foo"
+}

--- a/ext/uri/tests/rfc3986/getters/path_segments_success_one_uri.phpt
+++ b/ext/uri/tests/rfc3986/getters/path_segments_success_one_uri.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - path segments - URI with one non-empty segment
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://example.com/foo");
+
+var_dump($uri->getRawPathSegments());
+var_dump($uri->getPathSegments());
+
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  string(3) "foo"
+}
+array(1) {
+  [0]=>
+  string(3) "foo"
+}

--- a/ext/uri/tests/rfc3986/getters/path_segments_success_zero_path_reference.phpt
+++ b/ext/uri/tests/rfc3986/getters/path_segments_success_zero_path_reference.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - path segments - URI with zero segments
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("");
+
+var_dump($uri->getRawPathSegments());
+var_dump($uri->getPathSegments());
+
+?>
+--EXPECT--
+array(0) {
+}
+array(0) {
+}

--- a/ext/uri/tests/rfc3986/getters/path_segments_success_zero_uri.phpt
+++ b/ext/uri/tests/rfc3986/getters/path_segments_success_zero_uri.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - path segments - URI with zero segments
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://example.com");
+
+var_dump($uri->getRawPathSegments());
+var_dump($uri->getPathSegments());
+
+?>
+--EXPECT--
+array(0) {
+}
+array(0) {
+}

--- a/ext/uri/tests/rfc3986/getters/path_segments_success_zero_uri_empty_authority.phpt
+++ b/ext/uri/tests/rfc3986/getters/path_segments_success_zero_uri_empty_authority.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - path segments - URI without authority with zero segments
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://");
+
+var_dump($uri->getRawPathSegments());
+var_dump($uri->getPathSegments());
+
+?>
+--EXPECT--
+array(0) {
+}
+array(0) {
+}

--- a/ext/uri/tests/rfc3986/getters/path_segments_success_zero_uri_no_authority.phpt
+++ b/ext/uri/tests/rfc3986/getters/path_segments_success_zero_uri_no_authority.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test Uri\Rfc3986\Uri component retrieval - path segments - URI without authority with zero segments
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https:");
+
+var_dump($uri->getRawPathSegments());
+var_dump($uri->getPathSegments());
+
+?>
+--EXPECT--
+array(0) {
+}
+array(0) {
+}

--- a/ext/uri/tests/rfc3986/getters/query_params_success_basic.phpt
+++ b/ext/uri/tests/rfc3986/getters/query_params_success_basic.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test Uri\Rfc3986\Uri::getQueryParams() - success - basic
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://example.com/?%61bc=123&foo=b%61r"); // abc=123&foo=bar
+
+var_dump($uri->getRawQueryParams());
+var_dump($uri->getQueryParams());
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+}
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+}

--- a/ext/uri/tests/rfc3986/getters/query_params_success_empty.phpt
+++ b/ext/uri/tests/rfc3986/getters/query_params_success_empty.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test Uri\Rfc3986\Uri::getQueryParams() - success - empty query string
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://example.com/?");
+
+var_dump($uri->getRawQueryParams());
+var_dump($uri->getQueryParams());
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+}
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+}

--- a/ext/uri/tests/rfc3986/getters/query_params_success_non_existent.phpt
+++ b/ext/uri/tests/rfc3986/getters/query_params_success_non_existent.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test Uri\Rfc3986\Uri::getQueryParams() - success - non-existent query string
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://example.com/");
+
+var_dump($uri->getRawQueryParams());
+var_dump($uri->getQueryParams());
+
+?>
+--EXPECT--
+NULL
+NULL

--- a/ext/uri/tests/rfc3986/getters/uri_type_success_absolute_path_reference.phpt
+++ b/ext/uri/tests/rfc3986/getters/uri_type_success_absolute_path_reference.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\Rfc3986\Uri getter - uri type - Absolute path reference
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("/foo/bar");
+
+var_dump($uri->getUriType());
+
+?>
+--EXPECT--
+enum(Uri\Rfc3986\UriType::AbsolutePathReference)

--- a/ext/uri/tests/rfc3986/getters/uri_type_success_network_path_reference.phpt
+++ b/ext/uri/tests/rfc3986/getters/uri_type_success_network_path_reference.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\Rfc3986\Uri getter - uri type - Network path reference
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("//example.com/foo/bar");
+
+var_dump($uri->getUriType());
+
+?>
+--EXPECT--
+enum(Uri\Rfc3986\UriType::NetworkPathReference)

--- a/ext/uri/tests/rfc3986/getters/uri_type_success_relative_path_reference.phpt
+++ b/ext/uri/tests/rfc3986/getters/uri_type_success_relative_path_reference.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\Rfc3986\Uri getter - uri type - Relative path reference
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("foo/bar");
+
+var_dump($uri->getUriType());
+
+?>
+--EXPECT--
+enum(Uri\Rfc3986\UriType::RelativePathReference)

--- a/ext/uri/tests/rfc3986/getters/uri_type_success_uri_basic.phpt
+++ b/ext/uri/tests/rfc3986/getters/uri_type_success_uri_basic.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\Rfc3986\Uri getter - uri type - URI
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://example.com");
+
+var_dump($uri->getUriType());
+
+?>
+--EXPECT--
+enum(Uri\Rfc3986\UriType::Uri)

--- a/ext/uri/tests/rfc3986/getters/uri_type_success_uri_empty_authority.phpt
+++ b/ext/uri/tests/rfc3986/getters/uri_type_success_uri_empty_authority.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\Rfc3986\Uri getter - uri type - URI with empty authority
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https://");
+
+var_dump($uri->getUriType());
+
+?>
+--EXPECT--
+enum(Uri\Rfc3986\UriType::Uri)

--- a/ext/uri/tests/rfc3986/getters/uri_type_success_uri_no_authority.phpt
+++ b/ext/uri/tests/rfc3986/getters/uri_type_success_uri_no_authority.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\Rfc3986\Uri getter - uri type - URI without authority
+--FILE--
+<?php
+
+$uri = Uri\Rfc3986\Uri::parse("https:");
+
+var_dump($uri->getUriType());
+
+?>
+--EXPECT--
+enum(Uri\Rfc3986\UriType::Uri)

--- a/ext/uri/tests/rfc3986/modification/path_segments_success_multiple_absolute_path_reference.phpt
+++ b/ext/uri/tests/rfc3986/modification/path_segments_success_multiple_absolute_path_reference.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Test Uri\Rfc3986\Uri component modification - path segments - multiple segments to absolute path reference
+--EXTENSIONS--
+uri
+--FILE--
+<?php
+
+$uri1 = Uri\Rfc3986\Uri::parse("/foo");
+$uri2 = $uri1->withPathSegments(["foo", "bar", "baz"], true);
+
+var_dump($uri1->getRawPath());
+var_dump($uri1->getRawPathSegments());
+var_dump($uri2->getRawPath());
+var_dump($uri2->getRawPathSegments());
+var_dump($uri2->toRawString());
+var_dump($uri2->getPath());
+var_dump($uri2->getPathSegments());
+var_dump($uri2->toString());
+
+?>
+--EXPECT--
+string(4) "/foo"
+array(1) {
+  [0]=>
+  string(3) "foo"
+}
+string(12) "/foo/bar/baz"
+array(3) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "bar"
+  [2]=>
+  string(3) "baz"
+}
+string(12) "/foo/bar/baz"
+string(12) "/foo/bar/baz"
+array(3) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "bar"
+  [2]=>
+  string(3) "baz"
+}
+string(12) "/foo/bar/baz"

--- a/ext/uri/tests/rfc3986/modification/path_segments_success_multiple_relative_path_reference.phpt
+++ b/ext/uri/tests/rfc3986/modification/path_segments_success_multiple_relative_path_reference.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Test Uri\Rfc3986\Uri component modification - path segments - multiple segments to relative path reference
+--EXTENSIONS--
+uri
+--FILE--
+<?php
+
+$uri1 = Uri\Rfc3986\Uri::parse("/foo");
+$uri2 = $uri1->withPathSegments(["foo", "bar", "baz"], false);
+
+var_dump($uri1->getRawPath());
+var_dump($uri1->getRawPathSegments());
+var_dump($uri2->getRawPath());
+var_dump($uri2->getRawPathSegments());
+var_dump($uri2->toRawString());
+var_dump($uri2->getPath());
+var_dump($uri2->getPathSegments());
+var_dump($uri2->toString());
+
+?>
+--EXPECT--
+string(4) "/foo"
+array(1) {
+  [0]=>
+  string(3) "foo"
+}
+string(11) "foo/bar/baz"
+array(3) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "bar"
+  [2]=>
+  string(3) "baz"
+}
+string(11) "foo/bar/baz"
+string(11) "foo/bar/baz"
+array(3) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "bar"
+  [2]=>
+  string(3) "baz"
+}
+string(11) "foo/bar/baz"

--- a/ext/uri/tests/rfc3986/modification/path_segments_success_multiple_uri.phpt
+++ b/ext/uri/tests/rfc3986/modification/path_segments_success_multiple_uri.phpt
@@ -1,0 +1,46 @@
+--TEST--
+Test Uri\Rfc3986\Uri component modification - path segments - multiple path segments for URI
+--EXTENSIONS--
+uri
+--FILE--
+<?php
+
+$uri1 = Uri\Rfc3986\Uri::parse("https://example.com/foo");
+$uri2 = $uri1->withPathSegments(["foo", "bar", "baz"]);
+
+var_dump($uri1->getRawPath());
+var_dump($uri1->getRawPathSegments());
+var_dump($uri2->getRawPath());
+var_dump($uri2->getRawPathSegments());
+var_dump($uri2->toRawString());
+var_dump($uri2->getPath());
+var_dump($uri2->getPathSegments());
+var_dump($uri2->toString());
+
+?>
+--EXPECT--
+string(4) "/foo"
+array(1) {
+  [0]=>
+  string(3) "foo"
+}
+string(12) "/foo/bar/baz"
+array(3) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "bar"
+  [2]=>
+  string(3) "baz"
+}
+string(31) "https://example.com/foo/bar/baz"
+string(12) "/foo/bar/baz"
+array(3) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "bar"
+  [2]=>
+  string(3) "baz"
+}
+string(31) "https://example.com/foo/bar/baz"

--- a/ext/uri/tests/rfc3986/modification/path_segments_success_multiple_uri_trailing_slash.phpt
+++ b/ext/uri/tests/rfc3986/modification/path_segments_success_multiple_uri_trailing_slash.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Test Uri\Rfc3986\Uri component modification - path segments - multiple segments with trailing slash for URI
+--EXTENSIONS--
+uri
+--FILE--
+<?php
+
+$uri1 = Uri\Rfc3986\Uri::parse("https://example.com/foo");
+$uri2 = $uri1->withPathSegments(["foo", "bar", "baz", ""]);
+
+var_dump($uri1->getRawPath());
+var_dump($uri1->getRawPathSegments());
+var_dump($uri2->getRawPath());
+var_dump($uri2->getRawPathSegments());
+var_dump($uri2->toRawString());
+var_dump($uri2->getPath());
+var_dump($uri2->getPathSegments());
+var_dump($uri2->toString());
+
+?>
+--EXPECT--
+string(4) "/foo"
+array(1) {
+  [0]=>
+  string(3) "foo"
+}
+string(13) "/foo/bar/baz/"
+array(4) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "bar"
+  [2]=>
+  string(3) "baz"
+  [3]=>
+  string(0) ""
+}
+string(32) "https://example.com/foo/bar/baz/"
+string(13) "/foo/bar/baz/"
+array(4) {
+  [0]=>
+  string(3) "foo"
+  [1]=>
+  string(3) "bar"
+  [2]=>
+  string(3) "baz"
+  [3]=>
+  string(0) ""
+}
+string(32) "https://example.com/foo/bar/baz/"

--- a/ext/uri/tests/rfc3986/modification/path_segments_success_one_empty_path_reference.phpt
+++ b/ext/uri/tests/rfc3986/modification/path_segments_success_one_empty_path_reference.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Test Uri\Rfc3986\Uri component modification - path segments - one empty for path reference
+--EXTENSIONS--
+uri
+--FILE--
+<?php
+
+$uri1 = Uri\Rfc3986\Uri::parse("/foo");
+$uri2 = $uri1->withPathSegments([""]);
+
+var_dump($uri1->getRawPath());
+var_dump($uri1->getRawPathSegments());
+var_dump($uri2->getRawPath());
+var_dump($uri2->getRawPathSegments());
+var_dump($uri2->toRawString());
+var_dump($uri2->getPath());
+var_dump($uri2->getPathSegments());
+var_dump($uri2->toString());
+
+?>
+--EXPECT--
+string(4) "/foo"
+array(1) {
+  [0]=>
+  string(3) "foo"
+}
+string(1) "/"
+array(1) {
+  [0]=>
+  string(0) ""
+}
+string(1) "/"
+string(1) "/"
+array(1) {
+  [0]=>
+  string(0) ""
+}
+string(1) "/"
+

--- a/ext/uri/tests/rfc3986/modification/path_segments_success_one_empty_uri.phpt
+++ b/ext/uri/tests/rfc3986/modification/path_segments_success_one_empty_uri.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Test Uri\Rfc3986\Uri component modification - path segments - one empty for URI
+--EXTENSIONS--
+uri
+--FILE--
+<?php
+
+$uri1 = Uri\Rfc3986\Uri::parse("https://example.com/foo");
+$uri2 = $uri1->withPathSegments([""]);
+
+var_dump($uri1->getRawPath());
+var_dump($uri1->getRawPathSegments());
+var_dump($uri2->getRawPath());
+var_dump($uri2->getRawPathSegments());
+var_dump($uri2->toRawString());
+var_dump($uri2->getPath());
+var_dump($uri2->getPathSegments());
+var_dump($uri2->toString());
+
+?>
+--EXPECT--
+string(4) "/foo"
+array(1) {
+  [0]=>
+  string(3) "foo"
+}
+string(1) "/"
+array(1) {
+  [0]=>
+  string(0) ""
+}
+string(20) "https://example.com/"
+string(1) "/"
+array(1) {
+  [0]=>
+  string(0) ""
+}
+string(20) "https://example.com/"
+

--- a/ext/uri/tests/rfc3986/modification/path_segments_success_one_path_reference.phpt
+++ b/ext/uri/tests/rfc3986/modification/path_segments_success_one_path_reference.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Test Uri\Rfc3986\Uri component modification - path segments - one segment for path reference
+--EXTENSIONS--
+uri
+--FILE--
+<?php
+
+$uri1 = Uri\Rfc3986\Uri::parse("foo");
+$uri2 = $uri1->withPathSegments(["baz"], true);
+
+var_dump($uri1->getRawPath());
+var_dump($uri1->getRawPathSegments());
+var_dump($uri2->getRawPath());
+var_dump($uri2->getRawPathSegments());
+var_dump($uri2->toRawString());
+var_dump($uri2->getPath());
+var_dump($uri2->getPathSegments());
+var_dump($uri2->toString());
+
+?>
+--EXPECT--
+string(3) "foo"
+array(1) {
+  [0]=>
+  string(3) "foo"
+}
+string(4) "/baz"
+array(1) {
+  [0]=>
+  string(3) "baz"
+}
+string(4) "/baz"
+string(4) "/baz"
+array(1) {
+  [0]=>
+  string(3) "baz"
+}
+string(4) "/baz"

--- a/ext/uri/tests/rfc3986/modification/path_segments_success_one_uri.phpt
+++ b/ext/uri/tests/rfc3986/modification/path_segments_success_one_uri.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Test Uri\Rfc3986\Uri component modification - path segments - one segment for URI
+--EXTENSIONS--
+uri
+--FILE--
+<?php
+
+$uri1 = Uri\Rfc3986\Uri::parse("https://example.com/foo");
+$uri2 = $uri1->withPathSegments(["baz"]);
+
+var_dump($uri1->getRawPath());
+var_dump($uri1->getRawPathSegments());
+var_dump($uri2->getRawPath());
+var_dump($uri2->getRawPathSegments());
+var_dump($uri2->toRawString());
+var_dump($uri2->getPath());
+var_dump($uri2->getPathSegments());
+var_dump($uri2->toString());
+
+?>
+--EXPECT--
+string(4) "/foo"
+array(1) {
+  [0]=>
+  string(3) "foo"
+}
+string(4) "/baz"
+array(1) {
+  [0]=>
+  string(3) "baz"
+}
+string(23) "https://example.com/baz"
+string(4) "/baz"
+array(1) {
+  [0]=>
+  string(3) "baz"
+}
+string(23) "https://example.com/baz"

--- a/ext/uri/tests/rfc3986/modification/path_segments_success_zero_path_reference.phpt
+++ b/ext/uri/tests/rfc3986/modification/path_segments_success_zero_path_reference.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Test Uri\Rfc3986\Uri component modification - path segments - zero for path reference
+--EXTENSIONS--
+uri
+--FILE--
+<?php
+
+$uri1 = Uri\Rfc3986\Uri::parse("/foo");
+$uri2 = $uri1->withPathSegments([]);
+
+var_dump($uri1->getRawPath());
+var_dump($uri1->getRawPathSegments());
+var_dump($uri2->getRawPath());
+var_dump($uri2->getRawPathSegments());
+var_dump($uri2->toRawString());
+var_dump($uri2->getPath());
+var_dump($uri2->getPathSegments());
+var_dump($uri2->toString());
+
+?>
+--EXPECT--
+string(4) "/foo"
+array(1) {
+  [0]=>
+  string(3) "foo"
+}
+string(0) ""
+array(0) {
+}
+string(0) ""
+string(0) ""
+array(0) {
+}
+string(0) ""

--- a/ext/uri/tests/rfc3986/modification/path_segments_success_zero_uri.phpt
+++ b/ext/uri/tests/rfc3986/modification/path_segments_success_zero_uri.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Test Uri\Rfc3986\Uri component modification - path segments - zero segments for URI
+--EXTENSIONS--
+uri
+--FILE--
+<?php
+
+$uri1 = Uri\Rfc3986\Uri::parse("https://example.com/foo");
+$uri2 = $uri1->withPathSegments([]);
+
+var_dump($uri1->getRawPath());
+var_dump($uri1->getRawPathSegments());
+var_dump($uri2->getRawPath());
+var_dump($uri2->getRawPathSegments());
+var_dump($uri2->toRawString());
+var_dump($uri2->getPath());
+var_dump($uri2->getPathSegments());
+var_dump($uri2->toString());
+
+?>
+--EXPECT--
+string(4) "/foo"
+array(1) {
+  [0]=>
+  string(3) "foo"
+}
+string(0) ""
+array(0) {
+}
+string(19) "https://example.com"
+string(0) ""
+array(0) {
+}
+string(19) "https://example.com"

--- a/ext/uri/tests/rfc3986/modification/query_params_success_basic.phpt
+++ b/ext/uri/tests/rfc3986/modification/query_params_success_basic.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Test Uri\Rfc3986\Uri::withQueryParams() - success - basic
+--FILE--
+<?php
+
+$uri1 = Uri\Rfc3986\Uri::parse("https://example.com/");
+$queryParams = Uri\Rfc3986\UriQueryParams::parseRfc3986("abc=123&foo=bar");
+$uri2 = $uri1->withQueryParams($queryParams);
+
+var_dump($uri1->getRawQuery());
+var_dump($uri2->getRawQuery());
+var_dump($uri2->getQuery());
+var_dump($uri2->getRawQueryParams());
+var_dump($uri2->getQueryParams());
+var_dump($uri2->toString());
+
+?>
+--EXPECTF--
+NULL
+string(15) "abc=123&foo=bar"
+string(15) "abc=123&foo=bar"
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+}
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+}
+string(36) "https://example.com/?abc=123&foo=bar"

--- a/ext/uri/tests/rfc3986/percent_encoding/percent_decode_reserved_characters_success_basic.phpt
+++ b/ext/uri/tests/rfc3986/percent_encoding/percent_decode_reserved_characters_success_basic.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test Uri\Rfc3986\Uri::percentDecode() - success - reserved characters basic
+--FILE--
+<?php
+
+var_dump(Uri\Rfc3986\Uri::percentDecode(
+    "%3A %2F %3F %23 %5B %5D %40 %21 %24 %26 %27 %28 %29 %2A %2B %2C %3B %3D",
+    Uri\Rfc3986\UriPercentEncodingMode::AllReservedCharacters
+));
+
+?>
+--EXPECT--
+string(35) ": / ? # [ ] @ ! $ & ' ( ) * + , ; ="

--- a/ext/uri/tests/rfc3986/percent_encoding/percent_decode_reserved_characters_success_none.phpt
+++ b/ext/uri/tests/rfc3986/percent_encoding/percent_decode_reserved_characters_success_none.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Test Uri\Rfc3986\Uri::percentDecode() - success - reserved characters none
+--FILE--
+<?php
+
+var_dump(Uri\Rfc3986\Uri::percentDecode("foo 123 _ -", Uri\Rfc3986\UriPercentEncodingMode::AllReservedCharacters));
+
+?>
+--EXPECT--
+string(11) "foo 123 _ -"

--- a/ext/uri/tests/rfc3986/percent_encoding/percent_encode_reserved_characters_success_basic.phpt
+++ b/ext/uri/tests/rfc3986/percent_encoding/percent_encode_reserved_characters_success_basic.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Test Uri\Rfc3986\Uri::percentEncode() - success - reserved characters basic
+--FILE--
+<?php
+
+var_dump(Uri\Rfc3986\Uri::percentEncode(": / ? # [ ] @ ! $ & ' ( ) * + , ; =", Uri\Rfc3986\UriPercentEncodingMode::AllReservedCharacters));
+
+?>
+--EXPECT--
+string(71) "%3A %2F %3F %23 %5B %5D %40 %21 %24 %26 %27 %28 %29 %2A %2B %2C %3B %3D"

--- a/ext/uri/tests/rfc3986/percent_encoding/percent_encode_reserved_characters_success_none.phpt
+++ b/ext/uri/tests/rfc3986/percent_encoding/percent_encode_reserved_characters_success_none.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Test Uri\Rfc3986\Uri::percentEncode() - success - no reserved characters
+--FILE--
+<?php
+
+var_dump(Uri\Rfc3986\Uri::percentEncode("foo 123 _ -", Uri\Rfc3986\UriPercentEncodingMode::AllReservedCharacters));
+
+?>
+--EXPECT--
+string(11) "foo 123 _ -"

--- a/ext/uri/tests/rfc3986/percent_encoding/percent_encode_user_info_success_basic.phpt
+++ b/ext/uri/tests/rfc3986/percent_encoding/percent_encode_user_info_success_basic.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Test Uri\Rfc3986\Uri::percentEncode() - success - user info
+--FILE--
+<?php
+
+var_dump(Uri\Rfc3986\Uri::percentEncode("us%rname:p@ssword", Uri\Rfc3986\UriPercentEncodingMode::UserInfo));
+
+?>
+--EXPECT--
+string(21) "us%25rname:p%40ssword"

--- a/ext/uri/tests/rfc3986/query_params/append_success_array.phpt
+++ b/ext/uri/tests/rfc3986/query_params/append_success_array.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test Uri\Rfc3986\UriQueryParams::append() - success - array value
+--FILE--
+<?php
+
+$params = Uri\Rfc3986\UriQueryParams::parseRfc3986("");
+$params->append("baz", [null, false, "key2" => true, 123, "", ["bla"]]);
+
+var_dump($params);
+var_dump($params->toRfc3986String());
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+  ["baz[0]"]=>
+  NULL
+  ["baz[1]"]=>
+  string(1) "0"
+  ["baz[key2]"]=>
+  string(1) "1"
+  ["baz[2]"]=>
+  string(3) "123"
+  ["baz[3]"]=>
+  string(0) ""
+  ["baz[4][]"]=>
+  string(3) "bla"
+}
+string(87) "baz%5B0%5D&baz%5B1%5D=0&baz%5Bkey2%5D=1&baz%5B2%5D=123&baz%5B3%5D=&baz%5B4%5D%5B%5D=bla"

--- a/ext/uri/tests/rfc3986/query_params/append_success_array_empty.phpt
+++ b/ext/uri/tests/rfc3986/query_params/append_success_array_empty.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test Uri\Rfc3986\UriQueryParams::append() - success - empty array value
+--FILE--
+<?php
+
+$params = Uri\Rfc3986\UriQueryParams::parseRfc3986("abc=123&foo=bar");
+$params->append("baz", []);
+
+var_dump($params);
+var_dump($params->toRfc3986String());
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+  ["baz"]=>
+  NULL
+}
+string(19) "abc=123&foo=bar&baz"

--- a/ext/uri/tests/rfc3986/query_params/append_success_array_multi_level_list.phpt
+++ b/ext/uri/tests/rfc3986/query_params/append_success_array_multi_level_list.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test Uri\Rfc3986\UriQueryParams::append() - success - multi-level array value
+--FILE--
+<?php
+
+$params = Uri\Rfc3986\UriQueryParams::parseRfc3986("");
+$params->append("foo", [[0 => "bar"], [123]]);
+
+var_dump($params);
+var_dump($params->toRfc3986String());
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+  ["foo[][]"]=>
+  string(3) "bar"
+  ["foo[][]"]=>
+  string(3) "123"
+}
+string(39) "foo%5B%5D%5B%5D=bar&foo%5B%5D%5B%5D=123"

--- a/ext/uri/tests/rfc3986/query_params/append_success_array_multi_level_map.phpt
+++ b/ext/uri/tests/rfc3986/query_params/append_success_array_multi_level_map.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test Uri\Rfc3986\UriQueryParams::append() - success - multi-level array value
+--FILE--
+<?php
+
+$params = Uri\Rfc3986\UriQueryParams::parseRfc3986("");
+$params->append("foo", ["bar" => [0 => "baz", 2 => 123, 3 => [], 4 => [1, 2, 3]]]);
+
+var_dump($params);
+var_dump($params->toRfc3986String());
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+  ["foo[bar][0]"]=>
+  string(3) "baz"
+  ["foo[bar][2]"]=>
+  string(3) "123"
+  ["foo[bar][3]"]=>
+  NULL
+  ["foo[bar][4][]"]=>
+  string(1) "1"
+  ["foo[bar][4][]"]=>
+  string(1) "2"
+  ["foo[bar][4][]"]=>
+  string(1) "3"
+}
+string(151) "foo%5Bbar%5D%5B0%5D=baz&foo%5Bbar%5D%5B2%5D=123&foo%5Bbar%5D%5B3%5D&foo%5Bbar%5D%5B4%5D%5B%5D=1&foo%5Bbar%5D%5B4%5D%5B%5D=2&foo%5Bbar%5D%5B4%5D%5B%5D=3"

--- a/ext/uri/tests/rfc3986/query_params/append_success_basic.phpt
+++ b/ext/uri/tests/rfc3986/query_params/append_success_basic.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test Uri\Rfc3986\UriQueryParams::append() - success - basic
+--FILE--
+<?php
+
+$params = Uri\Rfc3986\UriQueryParams::parseRfc3986("abc=123&foo=bar");
+$params->append("baz", "qux");
+
+var_dump($params);
+var_dump($params->toRfc3986String());
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+  ["baz"]=>
+  string(3) "qux"
+}
+string(23) "abc=123&foo=bar&baz=qux"

--- a/ext/uri/tests/rfc3986/query_params/append_success_bool.phpt
+++ b/ext/uri/tests/rfc3986/query_params/append_success_bool.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test Uri\Rfc3986\UriQueryParams::append() - success - bool value
+--FILE--
+<?php
+
+$params = Uri\Rfc3986\UriQueryParams::parseRfc3986("abc=123&foo=bar");
+$params->append("baz", false);
+$params->append("qux", true);
+
+var_dump($params);
+var_dump($params->toRfc3986String());
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+  ["baz"]=>
+  string(1) "0"
+  ["qux"]=>
+  string(1) "1"
+}
+string(27) "abc=123&foo=bar&baz=0&qux=1"

--- a/ext/uri/tests/rfc3986/query_params/append_success_existing.phpt
+++ b/ext/uri/tests/rfc3986/query_params/append_success_existing.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test Uri\Rfc3986\UriQueryParams::append() - success - existing parameter
+--FILE--
+<?php
+
+$params = Uri\Rfc3986\UriQueryParams::parseRfc3986("abc=123&foo=bar");
+$params->append("foo", "bar");
+
+var_dump($params);
+var_dump($params->toRfc3986String());
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+  ["foo"]=>
+  string(3) "bar"
+}
+string(23) "abc=123&foo=bar&foo=bar"

--- a/ext/uri/tests/rfc3986/query_params/append_success_int_value.phpt
+++ b/ext/uri/tests/rfc3986/query_params/append_success_int_value.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test Uri\Rfc3986\UriQueryParams::append() - success - integer value
+
+--FILE--
+<?php
+
+$params = Uri\Rfc3986\UriQueryParams::parseRfc3986("abc=123&foo=bar");
+$params->append("baz", 0);
+
+var_dump($params);
+var_dump($params->toRfc3986String());
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+  ["baz"]=>
+  string(1) "0"
+}
+string(21) "abc=123&foo=bar&baz=0"

--- a/ext/uri/tests/rfc3986/query_params/append_success_list.phpt
+++ b/ext/uri/tests/rfc3986/query_params/append_success_list.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test Uri\Rfc3986\UriQueryParams::append() - success - list
+--FILE--
+<?php
+
+$params = Uri\Rfc3986\UriQueryParams::parseRfc3986("foo=0");
+$params->append("foo", [1, 2, 3]);
+
+var_dump($params);
+var_dump($params->toRfc3986String());
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+  ["foo"]=>
+  string(1) "0"
+  ["foo[]"]=>
+  string(1) "1"
+  ["foo[]"]=>
+  string(1) "2"
+  ["foo[]"]=>
+  string(1) "3"
+}
+string(41) "foo=0&foo%5B%5D=1&foo%5B%5D=2&foo%5B%5D=3"

--- a/ext/uri/tests/rfc3986/query_params/parse_success_basic.phpt
+++ b/ext/uri/tests/rfc3986/query_params/parse_success_basic.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test Uri\Rfc3986\UriQueryParams::parseRfc3986() - success
+--FILE--
+<?php
+
+$params = Uri\Rfc3986\UriQueryParams::parseRfc3986("abc=123&foo=bar");
+
+var_dump($params);
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+}

--- a/ext/uri/tests/rfc3986/query_params/parse_success_empty.phpt
+++ b/ext/uri/tests/rfc3986/query_params/parse_success_empty.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test Uri\Rfc3986\UriQueryParams::parseRfc3986() - success - empty string
+--FILE--
+<?php
+
+$params = Uri\Rfc3986\UriQueryParams::parseRfc3986("");
+
+var_dump($params);
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+}

--- a/ext/uri/tests/rfc3986/query_params/parse_success_reserved.phpt
+++ b/ext/uri/tests/rfc3986/query_params/parse_success_reserved.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test Uri\Rfc3986\UriQueryParams::parseRfc3986() - success - reserved characters are not validated
+--FILE--
+<?php
+
+$params = Uri\Rfc3986\UriQueryParams::parseRfc3986("ab:c=#123&<foo>=b@r");
+
+var_dump($params);
+var_dump($params->toRfc3986String());
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+  ["ab:c"]=>
+  string(4) "#123"
+  ["<foo>"]=>
+  string(3) "b@r"
+}
+string(29) "ab%3Ac=%23123&%3Cfoo%3E=b%40r"

--- a/ext/uri/tests/rfc3986/query_params/parse_success_space.phpt
+++ b/ext/uri/tests/rfc3986/query_params/parse_success_space.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test Uri\Rfc3986\UriQueryParams::parseRfc3986() - success - space character
+--FILE--
+<?php
+
+$params = Uri\Rfc3986\UriQueryParams::parseRfc3986("a c=123&foo=b r");
+
+var_dump($params);
+var_dump($params->toRfc3986String());
+
+?>
+--EXPECTF--
+object(Uri\Rfc3986\UriQueryParams)#%d (%d) {
+  ["a c"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "b r"
+}
+string(15) "a+c=123&foo=b+r"

--- a/ext/uri/tests/rfc3986/query_params/to_string_success_basic.phpt
+++ b/ext/uri/tests/rfc3986/query_params/to_string_success_basic.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\Rfc3986\UriQueryParams::toRfc3986String() - success - basic
+--FILE--
+<?php
+
+$params = Uri\Rfc3986\UriQueryParams::parseRfc3986("abc=123&foo=bar");
+
+var_dump($params->toRfc3986String());
+
+?>
+--EXPECT--
+string(15) "abc=123&foo=bar"

--- a/ext/uri/tests/rfc3986/query_params/to_string_success_empty.phpt
+++ b/ext/uri/tests/rfc3986/query_params/to_string_success_empty.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\Rfc3986\UriQueryParams::toRfc3986String() - success - empty query string
+--FILE--
+<?php
+
+$params = Uri\Rfc3986\UriQueryParams::parseRfc3986("");
+
+var_dump($params->toRfc3986String());
+
+?>
+--EXPECT--
+string(0) ""

--- a/ext/uri/tests/rfc3986/query_params/to_string_success_value_empty.phpt
+++ b/ext/uri/tests/rfc3986/query_params/to_string_success_value_empty.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\Rfc3986\UriQueryParams::toRfc3986String() - success - empty values
+--FILE--
+<?php
+
+$params = Uri\Rfc3986\UriQueryParams::parseRfc3986("foo=&bar");
+
+var_dump($params->toRfc3986String());
+
+?>
+--EXPECT--
+string(8) "foo=&bar"

--- a/ext/uri/tests/whatwg/getters/host_type_success_domain.phpt
+++ b/ext/uri/tests/whatwg/getters/host_type_success_domain.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\WhatWg\Url component retrieval - host type - registered name
+--FILE--
+<?php
+
+$url = Uri\WhatWg\Url::parse("https://example.com");
+
+var_dump($url->getHostType());
+
+?>
+--EXPECT--
+enum(Uri\WhatWg\UrlHostType::Domain)

--- a/ext/uri/tests/whatwg/getters/host_type_success_empty.phpt
+++ b/ext/uri/tests/whatwg/getters/host_type_success_empty.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\WhatWg\Url component retrieval - host type - empty
+--FILE--
+<?php
+
+$url = Uri\WhatWg\Url::parse("file:///foo/bar");
+
+var_dump($url->getHostType());
+
+?>
+--EXPECT--
+enum(Uri\WhatWg\UrlHostType::Empty)

--- a/ext/uri/tests/whatwg/getters/host_type_success_ipv4.phpt
+++ b/ext/uri/tests/whatwg/getters/host_type_success_ipv4.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\WhatWg\Url component retrieval - host type - IPv4
+--FILE--
+<?php
+
+$url = Uri\WhatWg\Url::parse("https://192.168.0.1");
+
+var_dump($url->getHostType());
+
+?>
+--EXPECT--
+enum(Uri\WhatWg\UrlHostType::IPv4)

--- a/ext/uri/tests/whatwg/getters/host_type_success_ipv6.phpt
+++ b/ext/uri/tests/whatwg/getters/host_type_success_ipv6.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\WhatWg\Url component retrieval - host type - IPv6
+--FILE--
+<?php
+
+$url = Uri\WhatWg\Url::parse("https://[2001:0db8:3333:4444:5555:6666:7777:8888]");
+
+var_dump($url->getHostType());
+
+?>
+--EXPECT--
+enum(Uri\WhatWg\UrlHostType::IPv6)

--- a/ext/uri/tests/whatwg/getters/host_type_success_none.phpt
+++ b/ext/uri/tests/whatwg/getters/host_type_success_none.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\WhatWg\Url component retrieval - host type - none
+--FILE--
+<?php
+
+$url = Uri\WhatWg\Url::parse("email:john.doe@example.com");
+
+var_dump($url->getHostType());
+
+?>
+--EXPECT--
+NULL

--- a/ext/uri/tests/whatwg/getters/host_type_success_opaque.phpt
+++ b/ext/uri/tests/whatwg/getters/host_type_success_opaque.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\WhatWg\Url component retrieval - host type - opaque
+--FILE--
+<?php
+
+$url = Uri\WhatWg\Url::parse("scheme://example.com");
+
+var_dump($url->getHostType());
+
+?>
+--EXPECT--
+enum(Uri\WhatWg\UrlHostType::Opaque)

--- a/ext/uri/tests/whatwg/getters/is_special_scheme_success_false.phpt
+++ b/ext/uri/tests/whatwg/getters/is_special_scheme_success_false.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\WhatWg\Url::isSpecialScheme() - success - not special
+--FILE--
+<?php
+
+$url = Uri\WhatWg\Url::parse("scheme://example.com");
+
+var_dump($url->isSpecialScheme());
+
+?>
+--EXPECT--
+bool(false)

--- a/ext/uri/tests/whatwg/getters/is_special_scheme_success_true.phpt
+++ b/ext/uri/tests/whatwg/getters/is_special_scheme_success_true.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test Uri\WhatWg\Url::isSpecialScheme() - success - https
+--FILE--
+<?php
+
+$url = Uri\WhatWg\Url::parse("http://example.com");
+var_dump($url->isSpecialScheme());
+
+$url = Uri\WhatWg\Url::parse("https://example.com");
+var_dump($url->isSpecialScheme());
+
+$url = Uri\WhatWg\Url::parse("ws://example.com");
+var_dump($url->isSpecialScheme());
+
+$url = Uri\WhatWg\Url::parse("wss://example.com");
+var_dump($url->isSpecialScheme());
+
+$url = Uri\WhatWg\Url::parse("ftp://example.com");
+var_dump($url->isSpecialScheme());
+
+$url = Uri\WhatWg\Url::parse("file://example.com");
+var_dump($url->isSpecialScheme());
+
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/ext/uri/tests/whatwg/getters/query_params_success_basic.phpt
+++ b/ext/uri/tests/whatwg/getters/query_params_success_basic.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test Uri\WhatWg\Url::getQueryParams() - success - basic
+--FILE--
+<?php
+
+$url = Uri\WhatWg\Url::parse("https://example.com/?%61bc=123&foo=b%61r"); // abc=123&foo=bar
+
+var_dump($url->getQueryParams());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+}

--- a/ext/uri/tests/whatwg/getters/query_params_success_empty.phpt
+++ b/ext/uri/tests/whatwg/getters/query_params_success_empty.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test Uri\WhatWg\Url::getQueryParams() - success - empty query string
+--FILE--
+<?php
+
+$url = Uri\WhatWg\Url::parse("https://example.com/?");
+
+var_dump($url->getQueryParams());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+}

--- a/ext/uri/tests/whatwg/getters/query_params_success_non_existent.phpt
+++ b/ext/uri/tests/whatwg/getters/query_params_success_non_existent.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\WhatWg\Url::getQueryParams() - success - non-existent query string
+--FILE--
+<?php
+
+$url = Uri\WhatWg\Url::parse("https://example.com/");
+
+var_dump($url->getQueryParams());
+
+?>
+--EXPECT--
+NULL

--- a/ext/uri/tests/whatwg/modification/query_params_success_basic.phpt
+++ b/ext/uri/tests/whatwg/modification/query_params_success_basic.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test Uri\WhatWg\Url::withQueryParams() - success - basic
+--FILE--
+<?php
+
+$uri1 = Uri\WhatWg\Url::parse("https://example.com/");
+$queryParams = Uri\WhatWg\UrlQueryParams::parse("abc=123&foo=bar");
+$uri2 = $uri1->withQueryParams($queryParams);
+
+var_dump($uri1->getQuery());
+var_dump($uri2->getQuery());
+var_dump($uri2->getQueryParams());
+var_dump($uri2->toAsciiString());
+
+?>
+--EXPECTF--
+NULL
+string(15) "abc=123&foo=bar"
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+}
+string(36) "https://example.com/?abc=123&foo=bar"

--- a/ext/uri/tests/whatwg/percent_encoding/percent_encode_path_success_basic.phpt
+++ b/ext/uri/tests/whatwg/percent_encoding/percent_encode_path_success_basic.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Test Uri\WhatWg\Url::percentEncode() - success - path
+--FILE--
+<?php
+
+var_dump(Uri\WhatWg\Url::percentEncode("/path@(/!+#abc", Uri\WhatWg\UrlPercentEncodingMode::UserInfo));
+
+?>
+--EXPECT--
+string(22) "%2Fpath%40(%2F!+%23abc"

--- a/ext/uri/tests/whatwg/percent_encoding/percent_encode_user_info_success_basic.phpt
+++ b/ext/uri/tests/whatwg/percent_encoding/percent_encode_user_info_success_basic.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Test Uri\WhatWg\Url::percentEncode() - success - user info
+--FILE--
+<?php
+
+var_dump(Uri\WhatWg\Url::percentEncode("us%rname:p@ssword", Uri\WhatWg\UrlPercentEncodingMode::UserInfo));
+
+?>
+--EXPECT--
+string(21) "us%rname%3Ap%40ssword"

--- a/ext/uri/tests/whatwg/query_params/append_success_array.phpt
+++ b/ext/uri/tests/whatwg/query_params/append_success_array.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::append() - success - array value
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("");
+$params->append("baz", [null, false, "key2" => true, 123, "", ["bla"]]);
+
+var_dump($params);
+var_dump($params->toString());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["baz[0]"]=>
+  string(0) ""
+  ["baz[1]"]=>
+  string(1) "0"
+  ["baz[key2]"]=>
+  string(1) "1"
+  ["baz[2]"]=>
+  string(3) "123"
+  ["baz[3]"]=>
+  string(0) ""
+  ["baz[4][]"]=>
+  string(3) "bla"
+}
+string(88) "baz%5B0%5D=&baz%5B1%5D=0&baz%5Bkey2%5D=1&baz%5B2%5D=123&baz%5B3%5D=&baz%5B4%5D%5B%5D=bla"

--- a/ext/uri/tests/whatwg/query_params/append_success_array_empty.phpt
+++ b/ext/uri/tests/whatwg/query_params/append_success_array_empty.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::append() - success - empty array value
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("abc=123&foo=bar");
+$params->append("baz", []);
+
+var_dump($params);
+var_dump($params->toString());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+  ["baz"]=>
+  string(0) ""
+}
+string(20) "abc=123&foo=bar&baz="

--- a/ext/uri/tests/whatwg/query_params/append_success_array_multi_level_list.phpt
+++ b/ext/uri/tests/whatwg/query_params/append_success_array_multi_level_list.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::append() - success - multi-level array value
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("");
+$params->append("foo", [[0 => "bar"], [123]]);
+
+var_dump($params);
+var_dump($params->toString());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["foo[][]"]=>
+  string(3) "bar"
+  ["foo[][]"]=>
+  string(3) "123"
+}
+string(39) "foo%5B%5D%5B%5D=bar&foo%5B%5D%5B%5D=123"

--- a/ext/uri/tests/whatwg/query_params/append_success_array_multi_level_map.phpt
+++ b/ext/uri/tests/whatwg/query_params/append_success_array_multi_level_map.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::append() - success - multi-level array value
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("");
+$params->append("foo", ["bar" => [0 => "baz", 2 => 123, 3 => [], 4 => [1, 2, 3]]]);
+
+var_dump($params);
+var_dump($params->toString());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["foo[bar][0]"]=>
+  string(3) "baz"
+  ["foo[bar][2]"]=>
+  string(3) "123"
+  ["foo[bar][3]"]=>
+  string(0) ""
+  ["foo[bar][4][]"]=>
+  string(1) "1"
+  ["foo[bar][4][]"]=>
+  string(1) "2"
+  ["foo[bar][4][]"]=>
+  string(1) "3"
+}
+string(152) "foo%5Bbar%5D%5B0%5D=baz&foo%5Bbar%5D%5B2%5D=123&foo%5Bbar%5D%5B3%5D=&foo%5Bbar%5D%5B4%5D%5B%5D=1&foo%5Bbar%5D%5B4%5D%5B%5D=2&foo%5Bbar%5D%5B4%5D%5B%5D=3"

--- a/ext/uri/tests/whatwg/query_params/append_success_basic.phpt
+++ b/ext/uri/tests/whatwg/query_params/append_success_basic.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::append() - success - basic
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("abc=123&foo=bar");
+$params->append("baz", "qux");
+
+var_dump($params);
+var_dump($params->toString());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+  ["baz"]=>
+  string(3) "qux"
+}
+string(23) "abc=123&foo=bar&baz=qux"

--- a/ext/uri/tests/whatwg/query_params/append_success_bool.phpt
+++ b/ext/uri/tests/whatwg/query_params/append_success_bool.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::append() - success - bool value
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("abc=123&foo=bar");
+$params->append("baz", false);
+$params->append("qux", true);
+
+var_dump($params);
+var_dump($params->toString());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+  ["baz"]=>
+  string(1) "0"
+  ["qux"]=>
+  string(1) "1"
+}
+string(27) "abc=123&foo=bar&baz=0&qux=1"

--- a/ext/uri/tests/whatwg/query_params/append_success_existing.phpt
+++ b/ext/uri/tests/whatwg/query_params/append_success_existing.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::append() - success - existing parameter
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("abc=123&foo=bar");
+$params->append("foo", "bar");
+
+var_dump($params);
+var_dump($params->toString());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+  ["foo"]=>
+  string(3) "bar"
+}
+string(23) "abc=123&foo=bar&foo=bar"

--- a/ext/uri/tests/whatwg/query_params/append_success_int_value.phpt
+++ b/ext/uri/tests/whatwg/query_params/append_success_int_value.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::append() - success - integer value
+
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("abc=123&foo=bar");
+$params->append("baz", 0);
+
+var_dump($params);
+var_dump($params->toString());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+  ["baz"]=>
+  string(1) "0"
+}
+string(21) "abc=123&foo=bar&baz=0"

--- a/ext/uri/tests/whatwg/query_params/append_success_list.phpt
+++ b/ext/uri/tests/whatwg/query_params/append_success_list.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::append() - success - list
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("foo=0");
+$params->append("foo", [1, 2, 3]);
+
+var_dump($params);
+var_dump($params->toString());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["foo"]=>
+  string(1) "0"
+  ["foo[]"]=>
+  string(1) "1"
+  ["foo[]"]=>
+  string(1) "2"
+  ["foo[]"]=>
+  string(1) "3"
+}
+string(41) "foo=0&foo%5B%5D=1&foo%5B%5D=2&foo%5B%5D=3"

--- a/ext/uri/tests/whatwg/query_params/delete_success_basic.phpt
+++ b/ext/uri/tests/whatwg/query_params/delete_success_basic.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::delete() - success - basic
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("abc=123&foo=bar");
+$params->delete("abc");
+
+var_dump($params);
+var_dump($params->toString());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["foo"]=>
+  string(3) "bar"
+}
+string(7) "foo=bar"

--- a/ext/uri/tests/whatwg/query_params/delete_success_multiple.phpt
+++ b/ext/uri/tests/whatwg/query_params/delete_success_multiple.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::delete() - success - basic
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("abc=123&foo=bar&foo=baz");
+$params->delete("foo");
+
+var_dump($params);
+var_dump($params->toString());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+}
+string(7) "abc=123"

--- a/ext/uri/tests/whatwg/query_params/delete_success_nonexistent.phpt
+++ b/ext/uri/tests/whatwg/query_params/delete_success_nonexistent.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::delete() - success - nonexistent key
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("abc=123&foo=bar");
+$params->delete("baz");
+
+var_dump($params);
+var_dump($params->toString());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+}
+string(15) "abc=123&foo=bar"

--- a/ext/uri/tests/whatwg/query_params/get_first_success_multiple.phpt
+++ b/ext/uri/tests/whatwg/query_params/get_first_success_multiple.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::get_first() - success - multiple items
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("foo=bar&foo=baz&foo=qux");
+
+var_dump($params->getFirst("foo"));
+
+?>
+--EXPECT--
+string(3) "bar"

--- a/ext/uri/tests/whatwg/query_params/get_first_success_non_existent.phpt
+++ b/ext/uri/tests/whatwg/query_params/get_first_success_non_existent.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::get_first() - success - item not exists
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("foo=bar&foo=baz&foo=qux");
+
+var_dump($params->getFirst("baz"));
+
+?>
+--EXPECT--
+NULL

--- a/ext/uri/tests/whatwg/query_params/has_success_false.phpt
+++ b/ext/uri/tests/whatwg/query_params/has_success_false.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::has() - success - basic
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("abc=123&foo=bar");
+
+var_dump($params->has("baz"));
+
+?>
+--EXPECT--
+bool(false)

--- a/ext/uri/tests/whatwg/query_params/has_success_true.phpt
+++ b/ext/uri/tests/whatwg/query_params/has_success_true.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::has() - success - basic
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("abc=123&foo=bar");
+
+var_dump($params->has("abc"));
+
+?>
+--EXPECT--
+bool(true)

--- a/ext/uri/tests/whatwg/query_params/parse_success_basic.phpt
+++ b/ext/uri/tests/whatwg/query_params/parse_success_basic.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::parse() - success
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("abc=123&foo=bar");
+
+var_dump($params);
+var_dump($params->toString());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+}
+string(15) "abc=123&foo=bar"

--- a/ext/uri/tests/whatwg/query_params/parse_success_empty.phpt
+++ b/ext/uri/tests/whatwg/query_params/parse_success_empty.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::parse() - success - empty string
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("");
+
+var_dump($params);
+var_dump($params->toString());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+}
+string(0) ""

--- a/ext/uri/tests/whatwg/query_params/parse_success_encoding_set1.phpt
+++ b/ext/uri/tests/whatwg/query_params/parse_success_encoding_set1.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::parse() - success - characters in the query string percent-encode set
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("ab:c=#123&<foo>=b@r");
+
+var_dump($params);
+var_dump($params->toString());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["ab:c"]=>
+  string(4) "#123"
+  ["<foo>"]=>
+  string(3) "b@r"
+}
+string(29) "ab%3Ac=%23123&%3Cfoo%3E=b%40r"

--- a/ext/uri/tests/whatwg/query_params/parse_success_encoding_set2.phpt
+++ b/ext/uri/tests/whatwg/query_params/parse_success_encoding_set2.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::parse() - success - characters in the application/x-www-form-urlencoded percent-encode set
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("abc!=123&foo'=bar)");
+
+var_dump($params);
+var_dump($params->toString());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["abc!"]=>
+  string(3) "123"
+  ["foo'"]=>
+  string(4) "bar)"
+}
+string(24) "abc%21=123&foo%27=bar%29"

--- a/ext/uri/tests/whatwg/query_params/parse_success_space.phpt
+++ b/ext/uri/tests/whatwg/query_params/parse_success_space.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::parse() - success - space character
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("a c=123&foo=b r");
+
+var_dump($params);
+var_dump($params->toString());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["a c"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "b r"
+}
+string(15) "a+c=123&foo=b+r"

--- a/ext/uri/tests/whatwg/query_params/query_params_success_basic.phpt
+++ b/ext/uri/tests/whatwg/query_params/query_params_success_basic.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test Uri\WhatWg\Url::getQueryParams() - success - basic
+--FILE--
+<?php
+
+$uri = Uri\WhatWg\Url::parse("https://example.com/?%61bc=123&foo=b%61r"); // abc=123&foo=bar
+
+var_dump($uri->getQueryParams());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+  ["abc"]=>
+  string(3) "123"
+  ["foo"]=>
+  string(3) "bar"
+}

--- a/ext/uri/tests/whatwg/query_params/query_params_success_empty.phpt
+++ b/ext/uri/tests/whatwg/query_params/query_params_success_empty.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test Uri\WhatWg\Url::getQueryParams() - success - empty query string
+--FILE--
+<?php
+
+$uri = Uri\WhatWg\Url::parse("https://example.com/?");
+
+var_dump($uri->getQueryParams());
+
+?>
+--EXPECTF--
+object(Uri\WhatWg\UrlQueryParams)#%d (%d) {
+}

--- a/ext/uri/tests/whatwg/query_params/query_params_success_non_existent.phpt
+++ b/ext/uri/tests/whatwg/query_params/query_params_success_non_existent.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\WhatWg\Url::getQueryParams() - success - non-existent query string
+--FILE--
+<?php
+
+$uri = Uri\WhatWg\Url::parse("https://example.com/");
+
+var_dump($uri->getQueryParams());
+
+?>
+--EXPECT--
+NULL

--- a/ext/uri/tests/whatwg/query_params/to_string_success_basic.phpt
+++ b/ext/uri/tests/whatwg/query_params/to_string_success_basic.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::toString() - success - basic
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("abc=123&foo=bar");
+
+var_dump($params->toString());
+
+?>
+--EXPECT--
+string(15) "abc=123&foo=bar"

--- a/ext/uri/tests/whatwg/query_params/to_string_success_empty.phpt
+++ b/ext/uri/tests/whatwg/query_params/to_string_success_empty.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::toString() - success - empty query string
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("");
+
+var_dump($params->toString());
+
+?>
+--EXPECT--
+string(0) ""

--- a/ext/uri/tests/whatwg/query_params/to_string_success_value_empty.phpt
+++ b/ext/uri/tests/whatwg/query_params/to_string_success_value_empty.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Uri\WhatWg\UrlQueryParams::toString() - success - empty values
+--FILE--
+<?php
+
+$params = Uri\WhatWg\UrlQueryParams::parse("foo=&bar");
+
+var_dump($params->toString());
+
+?>
+--EXPECT--
+string(9) "foo=&bar="

--- a/ext/uri/uri_parser_rfc3986.c
+++ b/ext/uri/uri_parser_rfc3986.c
@@ -17,6 +17,7 @@
 #include "php.h"
 #include "uri_parser_rfc3986.h"
 #include "php_uri_common.h"
+#include "Zend/zend_enum.h"
 #include "Zend/zend_smart_str.h"
 #include "Zend/zend_exceptions.h"
 
@@ -67,6 +68,544 @@ static const UriMemoryManager php_uri_parser_rfc3986_memory_manager = {
  * const struct with a non-const pointer for convenience. */
 static UriMemoryManager* const mm = (UriMemoryManager*)&php_uri_parser_rfc3986_memory_manager;
 
+#define PERCENT_ENCODE_COLON_CASE(retval) \
+	case ':': \
+		smart_str_appends(&retval, "%3A"); \
+		break;
+
+#define PERCENT_ENCODE_SLASH_CASE(retval) \
+	case '/': \
+		smart_str_appends(&retval, "%2F"); \
+		break;
+
+#define PERCENT_ENCODE_AT_CASE(retval) \
+	case '@': \
+		smart_str_appends(&retval, "%40"); \
+		break;
+
+#define PERCENT_ENCODE_QUESTION_MARK_CASE(retval) \
+	case '?': \
+		smart_str_appends(&retval, "%3F"); \
+		break;
+
+#define PERCENT_ENCODE_REST_OF_GEN_DELIMS_CASES(retval) \
+	case '#': \
+		smart_str_appends(&retval, "%23"); \
+		break; \
+	case '[': \
+		smart_str_appends(&retval, "%5B"); \
+		break; \
+	case ']': \
+		smart_str_appends(&retval, "%5D"); \
+		break;
+
+#define PERCENT_ENCODE_PERCENT_CASE(retval) \
+	case '%': \
+		smart_str_appends(&retval, "%25"); \
+		break;
+
+#define PERCENT_ENCODE_PERCENT_AS_PLUS_CASE(retval) \
+	case '%': \
+		smart_str_appends(&retval, "+"); \
+		break;
+
+#define PERCENT_ENCODE_OTHER_CHARACTERS_CASES(retval) \
+	case ' ': \
+		smart_str_appends(&retval, "%20"); \
+		break; \
+	case '"': \
+		smart_str_appends(&retval, "%22"); \
+		break; \
+	case '<': \
+		smart_str_appends(&retval, "%3C"); \
+		break; \
+	case '>': \
+		smart_str_appends(&retval, "%3E"); \
+		break; \
+	case '\\': \
+		smart_str_appends(&retval, "%5C"); \
+		break; \
+	case '^': \
+		smart_str_appends(&retval, "%5E"); \
+		break; \
+	case '`': \
+		smart_str_appends(&retval, "%60"); \
+		break; \
+	case '{': \
+		smart_str_appends(&retval, "%7B"); \
+		break; \
+	case '|': \
+		smart_str_appends(&retval, "%7C"); \
+		break; \
+	case '}': \
+		smart_str_appends(&retval, "%7D"); \
+		break;
+
+#define PERCENT_ENCODE_GEN_DELIMS_CASES(retval) \
+	PERCENT_ENCODE_COLON_CASE(retval) \
+	PERCENT_ENCODE_SLASH_CASE(retval) \
+	PERCENT_ENCODE_QUESTION_MARK_CASE(retval) \
+	PERCENT_ENCODE_AT_CASE(retval) \
+	PERCENT_ENCODE_REST_OF_GEN_DELIMS_CASES(retval)
+
+#define PERCENT_ENCODE_SUB_DELIMS_CASES(retval) \
+	case '!': \
+		smart_str_appends(&retval, "%21"); \
+		break; \
+	case '$': \
+		smart_str_appends(&retval, "%24"); \
+		break; \
+	case '&': \
+		smart_str_appends(&retval, "%26"); \
+		break; \
+	case '\'': \
+		smart_str_appends(&retval, "%27"); \
+		break; \
+	case '(': \
+		smart_str_appends(&retval, "%28"); \
+		break; \
+	case ')': \
+		smart_str_appends(&retval, "%29"); \
+		break; \
+	case '*': \
+		smart_str_appends(&retval, "%2A"); \
+		break; \
+	case '+': \
+		smart_str_appends(&retval, "%2B"); \
+		break; \
+	case ',': \
+		smart_str_appends(&retval, "%2C"); \
+		break; \
+	case ';': \
+		smart_str_appends(&retval, "%3B"); \
+		break; \
+	case '=': \
+		smart_str_appends(&retval, "%3D"); \
+		break;
+
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_user_info(const zend_string *str)
+{
+	/* userinfo      = *( unreserved / pct-encoded / sub-delims / ":" ) */
+	smart_str retval = {0};
+
+	for (int i = 0; i < ZSTR_LEN(str); i++) {
+		switch (ZSTR_VAL(str)[i]) {
+			/* PERCENT_ENCODE_COLON_CASE(retval) */
+			PERCENT_ENCODE_SLASH_CASE(retval)
+			PERCENT_ENCODE_QUESTION_MARK_CASE(retval)
+			PERCENT_ENCODE_AT_CASE(retval)
+			PERCENT_ENCODE_REST_OF_GEN_DELIMS_CASES(retval)
+			PERCENT_ENCODE_PERCENT_CASE(retval)
+			PERCENT_ENCODE_OTHER_CHARACTERS_CASES(retval)
+			default:
+				smart_str_appendc(&retval, ZSTR_VAL(str)[i]);
+				break;
+		}
+	}
+
+	return smart_str_extract(&retval);
+}
+
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_host(const zend_string *str)
+{
+	/* host         = IP-literal / IPv4address / reg-name
+	 * IP-literal   = "[" ( IPv6address / IPvFuture  ) "]"
+	 * IPvFuture    = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
+	 * IPv6address  =                            6( h16 ":" ) ls32
+	 *				/                       "::" 5( h16 ":" ) ls32
+	 *				/ [               h16 ] "::" 4( h16 ":" ) ls32
+	 *				/ [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
+	 *				/ [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32
+	 *				/ [ *3( h16 ":" ) h16 ] "::"    h16 ":"   ls32
+	 *				/ [ *4( h16 ":" ) h16 ] "::"              ls32
+	 *				/ [ *5( h16 ":" ) h16 ] "::"              h16
+	 *				/ [ *6( h16 ":" ) h16 ] "::"
+	 * h16           = 1*4HEXDIG
+	 * ls32          = ( h16 ":" h16 ) / IPv4address
+	 * IPv4address   = dec-octet "." dec-octet "." dec-octet "." dec-octet
+	 * dec-octet     = DIGIT                 ; 0-9
+	 *				/ %x31-39 DIGIT         ; 10-99
+	 *				/ "1" 2DIGIT            ; 100-199
+	 *				/ "2" %x30-34 DIGIT     ; 200-249
+	 *				/ "25" %x30-35          ; 250-255
+	 * reg-name      = *( unreserved / pct-encoded / sub-delims )
+	 */
+	smart_str retval = {0};
+
+	/* Is IP-literal */
+	if (ZSTR_LEN(str) > 0 && ZSTR_VAL(str)[0] == '[') {
+		smart_str_append(&retval, str);
+	} else { /* reg-name or IPv4address -> only reg-name supports percent-encoding */
+		for (int i = 0; i < ZSTR_LEN(str); i++) {
+			switch (ZSTR_VAL(str)[i]) {
+				PERCENT_ENCODE_GEN_DELIMS_CASES(retval)
+				PERCENT_ENCODE_PERCENT_CASE(retval)
+				PERCENT_ENCODE_OTHER_CHARACTERS_CASES(retval)
+				default:
+					smart_str_appendc(&retval, ZSTR_VAL(str)[i]);
+					break;
+			}
+		}
+	}
+
+	return smart_str_extract(&retval);
+}
+
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_path(const zend_string *str)
+{
+	/* path-abempty  = *( "/" segment )
+	 * path-absolute = "/" [ segment-nz *( "/" segment ) ]
+	 * path-rootless = segment-nz *( "/" segment )
+	 * path-empty    = 0<pchar>
+	 * segment       = *pchar
+	 * segment-nz    = 1*pchar
+	 * pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+	 */
+	smart_str retval = {0};
+
+	for (int i = 0; i < ZSTR_LEN(str); i++) {
+		switch (ZSTR_VAL(str)[i]) {
+			/* PERCENT_ENCODE_COLON_CASE(retval) */
+			/* PERCENT_ENCODE_SLASH_CASE(retval) */
+			PERCENT_ENCODE_QUESTION_MARK_CASE(retval)
+			/* PERCENT_ENCODE_AT_CASE(retval) */
+			PERCENT_ENCODE_REST_OF_GEN_DELIMS_CASES(retval)
+			PERCENT_ENCODE_PERCENT_CASE(retval)
+			PERCENT_ENCODE_OTHER_CHARACTERS_CASES(retval)
+			default:
+				smart_str_appendc(&retval, ZSTR_VAL(str)[i]);
+				break;
+		}
+	}
+
+	return smart_str_extract(&retval);
+}
+
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_path_segment(const zend_string *str)
+{
+	/* segment       = *pchar
+	 * segment-nz    = 1*pchar
+	 * pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+	 */
+	smart_str retval = {0};
+
+	for (int i = 0; i < ZSTR_LEN(str); i++) {
+		switch (ZSTR_VAL(str)[i]) {
+			/* PERCENT_ENCODE_COLON_CASE(retval) */
+			PERCENT_ENCODE_SLASH_CASE(retval)
+			PERCENT_ENCODE_QUESTION_MARK_CASE(retval)
+			/* PERCENT_ENCODE_AT_CASE(retval) */
+			PERCENT_ENCODE_REST_OF_GEN_DELIMS_CASES(retval)
+			PERCENT_ENCODE_PERCENT_CASE(retval)
+			PERCENT_ENCODE_OTHER_CHARACTERS_CASES(retval)
+			default:
+			smart_str_appendc(&retval, ZSTR_VAL(str)[i]);
+			break;
+		}
+	}
+
+	return smart_str_extract(&retval);
+}
+
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_relative_reference_path(const zend_string *str)
+{
+	/* path-noscheme = segment-nz-nc *( "/" segment )
+	 * segment-nz-nc = 1*( unreserved / pct-encoded / sub-delims / "@" )
+	 * pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+	 */
+	smart_str retval = {0};
+	bool first_segment = true;
+
+	for (int i = 0; i < ZSTR_LEN(str); i++) {
+		switch (ZSTR_VAL(str)[i]) {
+			case '/':
+				first_segment = false;
+				break;
+			case ':':
+				if (first_segment) {
+					smart_str_appends(&retval, "%3A");
+				} else {
+					smart_str_appendc(&retval, ZSTR_VAL(str)[i]);
+				}
+				break;
+				/* PERCENT_ENCODE_SLASH_CASE(retval) */
+				PERCENT_ENCODE_QUESTION_MARK_CASE(retval)
+				/* PERCENT_ENCODE_AT_CASE(retval) */
+				PERCENT_ENCODE_REST_OF_GEN_DELIMS_CASES(retval)
+				PERCENT_ENCODE_PERCENT_CASE(retval)
+				PERCENT_ENCODE_OTHER_CHARACTERS_CASES(retval)
+				default:
+					smart_str_appendc(&retval, ZSTR_VAL(str)[i]);
+					break;
+		}
+	}
+
+	return smart_str_extract(&retval);
+}
+
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_relative_reference_first_path_segment(const zend_string *str)
+{
+	/* segment-nz-nc = 1*( unreserved / pct-encoded / sub-delims / "@" ) */
+	smart_str retval = {0};
+
+	for (int i = 0; i < ZSTR_LEN(str); i++) {
+		switch (ZSTR_VAL(str)[i]) {
+			PERCENT_ENCODE_COLON_CASE(retval)
+			PERCENT_ENCODE_SLASH_CASE(retval)
+			PERCENT_ENCODE_QUESTION_MARK_CASE(retval)
+			/* PERCENT_ENCODE_AT_CASE(retval) */
+			PERCENT_ENCODE_REST_OF_GEN_DELIMS_CASES(retval)
+			PERCENT_ENCODE_PERCENT_CASE(retval)
+			PERCENT_ENCODE_OTHER_CHARACTERS_CASES(retval)
+			default:
+				smart_str_appendc(&retval, ZSTR_VAL(str)[i]);
+				break;
+		}
+	}
+
+	return smart_str_extract(&retval);
+}
+
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_query_or_fragment(const zend_string *str)
+{
+	/* query         = *( pchar / "/" / "?" ) */
+	/* fragment      = *( pchar / "/" / "?" ) */
+	/* pchar         = unreserved / pct-encoded / sub-delims / ":" / "@" */
+	smart_str retval = {0};
+
+	for (int i = 0; i < ZSTR_LEN(str); i++) {
+		switch (ZSTR_VAL(str)[i]) {
+			/* PERCENT_ENCODE_COLON_CASE(retval) */
+			/* PERCENT_ENCODE_SLASH_CASE(retval) */
+			/* PERCENT_ENCODE_QUESTION_MARK_CASE(retval) */
+			/* PERCENT_ENCODE_AT_CASE(retval) */
+			PERCENT_ENCODE_REST_OF_GEN_DELIMS_CASES(retval)
+			PERCENT_ENCODE_PERCENT_CASE(retval)
+			PERCENT_ENCODE_OTHER_CHARACTERS_CASES(retval)
+			default:
+				smart_str_appendc(&retval, ZSTR_VAL(str)[i]);
+				break;
+		}
+	}
+
+	return smart_str_extract(&retval);
+}
+
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_form_query(const zend_string *str)
+{
+	/* query         = *( pchar / "/" / "?" ) */
+	/* pchar         = unreserved / pct-encoded / sub-delims / ":" / "@" */
+	smart_str retval = {0};
+
+	for (int i = 0; i < ZSTR_LEN(str); i++) {
+		switch (ZSTR_VAL(str)[i]) {
+			/* PERCENT_ENCODE_COLON_CASE(retval) */
+			/* PERCENT_ENCODE_SLASH_CASE(retval) */
+			/* PERCENT_ENCODE_QUESTION_MARK_CASE(retval) */
+			/* PERCENT_ENCODE_AT_CASE(retval) */
+			PERCENT_ENCODE_REST_OF_GEN_DELIMS_CASES(retval)
+			PERCENT_ENCODE_PERCENT_AS_PLUS_CASE(retval)
+			PERCENT_ENCODE_OTHER_CHARACTERS_CASES(retval)
+			default:
+				smart_str_appendc(&retval, ZSTR_VAL(str)[i]);
+				break;
+		}
+	}
+
+	return smart_str_extract(&retval);
+}
+
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_reserved_characters(const zend_string *str)
+{
+	smart_str retval = {0};
+
+	/* gen-delims    ":" / "/" / "?" / "#" / "[" / "]" / "@"
+	 * sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
+	 *			     / "*" / "+" / "," / ";" / "="
+	 */
+
+	for (int i = 0; i < ZSTR_LEN(str); i++) {
+		switch (ZSTR_VAL(str)[i]) {
+			PERCENT_ENCODE_GEN_DELIMS_CASES(retval)
+			PERCENT_ENCODE_SUB_DELIMS_CASES(retval)
+			default:
+			smart_str_appendc(&retval, ZSTR_VAL(str)[i]);
+			break;
+		}
+	}
+
+	return smart_str_extract(&retval);
+}
+
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_all(const zend_string *str)
+{
+	smart_str retval = {0};
+
+	/* gen-delims    ":" / "/" / "?" / "#" / "[" / "]" / "@"
+	 * sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
+	 *			     / "*" / "+" / "," / ";" / "="
+	 */
+
+	for (int i = 0; i < ZSTR_LEN(str); i++) {
+		switch (ZSTR_VAL(str)[i]) {
+			PERCENT_ENCODE_GEN_DELIMS_CASES(retval)
+			PERCENT_ENCODE_SUB_DELIMS_CASES(retval)
+			PERCENT_ENCODE_PERCENT_CASE(retval)
+			PERCENT_ENCODE_OTHER_CHARACTERS_CASES(retval)
+			default:
+			smart_str_appendc(&retval, ZSTR_VAL(str)[i]);
+			break;
+		}
+	}
+
+	return smart_str_extract(&retval);
+}
+
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_decode(const zend_string *str)
+{
+	smart_str retval = {0};
+
+	smart_str_append(&retval, str);
+
+	return smart_str_extract(&retval);
+}
+
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_decode_reserved_characters(const zend_string *str)
+{
+	smart_str retval = {0};
+
+	/* gen-delims    ":" / "/" / "?" / "#" / "[" / "]" / "@"
+	 * sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
+	 *			     / "*" / "+" / "," / ";" / "="
+	 */
+
+	for (int i = 0; i < ZSTR_LEN(str); i++) {
+		switch (ZSTR_VAL(str)[i]) {
+			case '%':
+				if (i + 2 >= ZSTR_LEN(str)) {
+					return NULL;
+				}
+
+				switch (ZSTR_VAL(str)[i + 1]) {
+					case '2':
+						switch (ZSTR_VAL(str)[i + 2]) {
+							case 'F':
+								smart_str_appendc(&retval, '/');
+								i+= 2;
+								break;
+							case '3':
+								smart_str_appendc(&retval, '#');
+								i+= 2;
+								break;
+							case '1':
+								smart_str_appendc(&retval, '!');
+								i+= 2;
+								break;
+							case '4':
+								smart_str_appendc(&retval, '$');
+								i+= 2;
+								break;
+							case '6':
+								smart_str_appendc(&retval, '&');
+								i+= 2;
+								break;
+							case '7':
+								smart_str_appendc(&retval, '\'');
+								i+= 2;
+								break;
+							case '8':
+								smart_str_appendc(&retval, '(');
+								i+= 2;
+								break;
+							case '9':
+								smart_str_appendc(&retval, ')');
+								i+= 2;
+								break;
+							case 'A':
+								smart_str_appendc(&retval, '*');
+								i+= 2;
+								break;
+							case 'B':
+								smart_str_appendc(&retval, '+');
+								i+= 2;
+								break;
+							case 'C':
+								smart_str_appendc(&retval, ',');
+								i+= 2;
+								break;
+							default:
+								smart_str_appendc(&retval, ZSTR_VAL(str)[i + 2]);
+								i+= 2;
+								break;
+						}
+						break;
+					case '3':
+						switch (ZSTR_VAL(str)[i + 2]) {
+							case 'A':
+									smart_str_appendc(&retval, ':');
+									i+= 2;
+									break;
+							case 'F':
+									smart_str_appendc(&retval, '?');
+									i+= 2;
+									break;
+							case 'B':
+									smart_str_appendc(&retval, ';');
+								i+= 2;
+									break;
+							case 'D':
+									smart_str_appendc(&retval, '=');
+									i+= 2;
+									break;
+							default:
+									smart_str_appendc(&retval, ZSTR_VAL(str)[i + 2]);
+									i+= 2;
+									break;
+						}
+						break;
+					case '4':
+						switch (ZSTR_VAL(str)[i + 2]) {
+							case '0':
+									smart_str_appendc(&retval, '@');
+									i+= 2;
+									break;
+							default:
+									smart_str_appendc(&retval, ZSTR_VAL(str)[i + 2]);
+									i+= 2;
+									break;
+						}
+						break;
+					case '5':
+						switch (ZSTR_VAL(str)[i + 2]) {
+							case 'B':
+									smart_str_appendc(&retval, '[');
+									i+= 2;
+									break;
+							case 'D':
+									smart_str_appendc(&retval, ']');
+									i+= 2;
+									break;
+							default:
+									smart_str_appendc(&retval, ZSTR_VAL(str)[i + 2]);
+									i+= 2;
+									break;
+						}
+						break;
+					default:
+						i+= 1;
+						smart_str_appendc(&retval, ZSTR_VAL(str)[i + 1]);
+						break;
+				}
+				break;
+			default:
+				smart_str_appendc(&retval, ZSTR_VAL(str)[i]);
+				break;
+		}
+	}
+
+	return smart_str_extract(&retval);
+}
+
 static inline size_t get_text_range_length(const UriTextRangeA *range)
 {
 	return range->afterLast - range->first;
@@ -111,6 +650,29 @@ ZEND_ATTRIBUTE_NONNULL static UriUriA *get_uri_for_writing(php_uri_parser_rfc398
 {
 	return &uriparser_uris->uri;
 }
+
+
+ZEND_ATTRIBUTE_NONNULL void php_uri_parser_rfc3986_uri_type_read(void *uri, zval *retval)
+{
+	const UriUriA *uriparser_uri = get_uri_for_reading(uri, PHP_URI_COMPONENT_READ_MODE_RAW);
+
+	if (has_text_range(&uriparser_uri->scheme)) {
+		ZVAL_OBJ_COPY(retval, zend_enum_get_case_cstr(php_uri_ce_rfc3986_uri_type, "Uri"));
+		return;
+	}
+
+	if (has_text_range(&uriparser_uri->hostText)) {
+		ZVAL_OBJ_COPY(retval, zend_enum_get_case_cstr(php_uri_ce_rfc3986_uri_type, "NetworkPathReference"));
+		return;
+	}
+
+	if (uriparser_uri->absolutePath) {
+		ZVAL_OBJ_COPY(retval, zend_enum_get_case_cstr(php_uri_ce_rfc3986_uri_type, "AbsolutePathReference"));
+	} else {
+		ZVAL_OBJ_COPY(retval, zend_enum_get_case_cstr(php_uri_ce_rfc3986_uri_type, "RelativePathReference"));
+	}
+}
+
 
 ZEND_ATTRIBUTE_NONNULL static zend_result php_uri_parser_rfc3986_scheme_read(void *uri, php_uri_component_read_mode read_mode, zval *retval)
 {
@@ -254,6 +816,26 @@ ZEND_ATTRIBUTE_NONNULL static zend_result php_uri_parser_rfc3986_host_read(void 
 	return SUCCESS;
 }
 
+ZEND_ATTRIBUTE_NONNULL void php_uri_parser_rfc3986_host_type_read(void *uri, php_uri_component_read_mode read_mode, zval *retval)
+{
+	const UriUriA *uriparser_uri = get_uri_for_reading(uri, read_mode);
+
+	if (!has_text_range(&uriparser_uri->hostText)) {
+		ZVAL_NULL(retval);
+		return;
+	}
+
+	if (uriparser_uri->hostData.ip4 != NULL) {
+		ZVAL_OBJ_COPY(retval, zend_enum_get_case_cstr(php_uri_ce_rfc3986_uri_host_type, "IPv4"));
+	} else if (uriparser_uri->hostData.ip6 != NULL) {
+		ZVAL_OBJ_COPY(retval, zend_enum_get_case_cstr(php_uri_ce_rfc3986_uri_host_type, "IPv6"));
+	} else if (has_text_range(&uriparser_uri->hostData.ipFuture)) {
+		ZVAL_OBJ_COPY(retval, zend_enum_get_case_cstr(php_uri_ce_rfc3986_uri_host_type, "IPvFuture"));
+	} else {
+		ZVAL_OBJ_COPY(retval, zend_enum_get_case_cstr(php_uri_ce_rfc3986_uri_host_type, "RegisteredName"));
+	}
+}
+
 static zend_result php_uri_parser_rfc3986_host_write(void *uri, zval *value, zval *errors)
 {
 	UriUriA *uriparser_uri = get_uri_for_writing(uri);
@@ -372,6 +954,32 @@ ZEND_ATTRIBUTE_NONNULL static zend_result php_uri_parser_rfc3986_path_read(void 
 	return SUCCESS;
 }
 
+zend_result php_uri_parser_rfc3986_path_segments_read(void *uri, php_uri_component_read_mode read_mode, zval *retval)
+{
+	const UriUriA *uriparser_uri = get_uri_for_reading(uri, read_mode);
+
+	if (uriparser_uri->pathHead != NULL) {
+		array_init(retval);
+
+		for (const UriPathSegmentA *p = uriparser_uri->pathHead; p; p = p->next) {
+			zval tmp;
+			ZVAL_STRINGL(&tmp,p->text.first, get_text_range_length(&p->text));
+			zend_hash_next_index_insert_new(Z_ARRVAL_P(retval), &tmp);
+		}
+	} else if (uriparser_uri->absolutePath) {
+		array_init(retval);
+		zval tmp;
+		ZVAL_EMPTY_STRING(&tmp);
+
+		zend_hash_next_index_insert_new(Z_ARRVAL_P(retval), &tmp);
+		zval_ptr_dtor(&tmp);
+	} else {
+		ZVAL_EMPTY_ARRAY(retval);
+	}
+
+	return SUCCESS;
+}
+
 static zend_result php_uri_parser_rfc3986_path_write(void *uri, zval *value, zval *errors)
 {
 	UriUriA *uriparser_uri = get_uri_for_writing(uri);
@@ -396,12 +1004,90 @@ static zend_result php_uri_parser_rfc3986_path_write(void *uri, zval *value, zva
 	}
 }
 
+zend_result php_uri_parser_rfc3986_path_segments_write(php_uri_parser_rfc3986_uris *uri, zval *value, bool include_leading_slash_for_non_empty_relative_uri)
+{
+	UriUriA *uriparser_uri = get_uri_for_writing(uri);
+	HashTable *segments = Z_ARR_P(value);
+	int result;
+
+	if (zend_array_count(segments) == 0) {
+		result = uriSetPathMmA(uriparser_uri, NULL, NULL, mm);
+	} else {
+		smart_str path = {0};
+		bool is_path_reference = !has_text_range(&uriparser_uri->scheme);
+		bool is_first_segment = true;
+
+		zval *tmp;
+		zend_ulong index_num;
+		zend_string *index_str = NULL;
+		ZEND_HASH_FOREACH_KEY_VAL(segments, index_num, index_str, tmp) {
+			if (index_str != NULL || index_num > 99999) { // TODO change
+				zend_argument_type_error(1, "must only have numeric keys, string given");
+				return FAILURE;
+			}
+
+			if (Z_TYPE_P(tmp) != IS_STRING) {
+				zend_argument_type_error(1, "must be a list of strings, %s given", zend_zval_value_name(tmp));
+				return FAILURE;
+			}
+
+			if (is_path_reference && is_first_segment && Z_STRLEN_P(tmp) > 0) {
+				if (include_leading_slash_for_non_empty_relative_uri) {
+					smart_str_appendc(&path, '/');
+				}
+			} else {
+				smart_str_appendc(&path, '/');
+			}
+
+			smart_str_append(&path, Z_STR_P(tmp));
+
+			is_first_segment = false;
+		} ZEND_HASH_FOREACH_END();
+
+		zend_string *str = smart_str_extract(&path);
+		result = uriSetPathMmA(uriparser_uri, ZSTR_VAL(str), ZSTR_VAL(str) + ZSTR_LEN(str), mm);
+		zend_string_release(str);
+	}
+
+	switch (result) {
+		case URI_SUCCESS:
+			return SUCCESS;
+		default:
+			/* This should be unreachable in practice. */
+			zend_throw_exception(php_uri_ce_error, "Failed to update the path", 0);
+			return FAILURE;
+	}
+}
+
 ZEND_ATTRIBUTE_NONNULL static zend_result php_uri_parser_rfc3986_query_read(void *uri, php_uri_component_read_mode read_mode, zval *retval)
 {
 	const UriUriA *uriparser_uri = get_uri_for_reading(uri, read_mode);
 
 	if (has_text_range(&uriparser_uri->query)) {
 		ZVAL_STRINGL(retval, uriparser_uri->query.first, get_text_range_length(&uriparser_uri->query));
+	} else {
+		ZVAL_NULL(retval);
+	}
+
+	return SUCCESS;
+}
+
+ZEND_ATTRIBUTE_NONNULL zend_result php_uri_parser_rfc3986_query_params_read(void *uri, php_uri_component_read_mode read_mode, zval *retval)
+{
+	const UriUriA *uriparser_uri = get_uri_for_reading(uri, read_mode);
+
+	if (has_text_range(&uriparser_uri->query)) {
+		object_init_ex(retval, php_uri_ce_rfc3986_uri_query_params);
+		php_uri_parser_rfc3986_uri_query_params_object *uri_query_params_object = Z_URI_QUERY_PARAMS_OBJECT_P(retval);
+
+		if (php_uri_rfc3986_uri_query_params_from_str(uriparser_uri->query.first, get_text_range_length(&uriparser_uri->query),
+			&uri_query_params_object->query_list, false
+		) == FAILURE) {
+			php_uri_rfc3986_uri_query_params_free(Z_URI_QUERY_PARAMS_OBJECT_P(retval));
+			return FAILURE;
+		}
+
+		uri_query_params_object->is_initialized = true;
 	} else {
 		ZVAL_NULL(retval);
 	}
@@ -418,6 +1104,36 @@ static zend_result php_uri_parser_rfc3986_query_write(void *uri, zval *value, zv
 		result = uriSetQueryMmA(uriparser_uri, NULL, NULL, mm);
 	} else {
 		result = uriSetQueryMmA(uriparser_uri, Z_STRVAL_P(value), Z_STRVAL_P(value) + Z_STRLEN_P(value), mm);
+	}
+
+	switch (result) {
+		case URI_SUCCESS:
+			return SUCCESS;
+		case URI_ERROR_SYNTAX:
+			zend_throw_exception(php_uri_ce_invalid_uri_exception, "The specified query is malformed", 0);
+			return FAILURE;
+		default:
+			/* This should be unreachable in practice. */
+			zend_throw_exception(php_uri_ce_error, "Failed to update the query", 0);
+			return FAILURE;
+	}
+}
+
+ZEND_ATTRIBUTE_NONNULL zend_result php_uri_parser_rfc3986_query_params_write(void *uri, zval *value)
+{
+	UriUriA *uriparser_uri = get_uri_for_writing(uri);
+	int result;
+
+	if (Z_TYPE_P(value) == IS_NULL) {
+		result = uriSetQueryMmA(uriparser_uri, NULL, NULL, mm);
+	} else {
+		ZEND_ASSERT(Z_TYPE_P(value) == IS_OBJECT && instanceof_function(Z_OBJCE_P(value), php_uri_ce_rfc3986_uri_query_params));
+		php_uri_parser_rfc3986_uri_query_params_object *uri_query_params_object = Z_URI_QUERY_PARAMS_OBJECT_P(value);
+		zend_string *query_string = php_uri_rfc3986_uri_query_params_to_string(uri_query_params_object->query_list);
+
+		result = uriSetQueryMmA(uriparser_uri, ZSTR_VAL(query_string), ZSTR_VAL(query_string) + ZSTR_LEN(query_string), mm);
+
+		zend_string_release(query_string);
 	}
 
 	switch (result) {
@@ -613,6 +1329,165 @@ static void php_uri_parser_rfc3986_destroy(void *uri)
 	uriFreeUriMembersMmA(&uriparser_uris->normalized_uri, mm);
 
 	efree(uriparser_uris);
+}
+
+ZEND_ATTRIBUTE_NONNULL PHPAPI void php_uri_rfc3986_uri_query_params_free(php_uri_parser_rfc3986_uri_query_params_object *uri_query_params_object)
+{
+	if (uri_query_params_object->query_list != NULL) {
+		uriFreeQueryListMmA(uri_query_params_object->query_list, mm);
+		uri_query_params_object->query_list = NULL;
+		uri_query_params_object->is_initialized = false;
+	}
+}
+
+ZEND_ATTRIBUTE_NONNULL PHPAPI void php_uri_rfc3986_uri_query_params_object_handler_free(zend_object *object)
+{
+	php_uri_parser_rfc3986_uri_query_params_object *uri_query_params_object = php_uri_rfc3986_uri_query_params_object_from_obj(object);
+
+	php_uri_rfc3986_uri_query_params_free(uri_query_params_object);
+
+	zend_object_std_dtor(&uri_query_params_object->std);
+}
+
+ZEND_ATTRIBUTE_NONNULL PHPAPI zend_object *php_uri_rfc3986_uri_query_params_object_handler_clone(zend_object *object)
+{
+	php_uri_parser_rfc3986_uri_query_params_object *uri_query_params_object = php_uri_rfc3986_uri_query_params_object_from_obj(object);
+
+	php_uri_parser_rfc3986_uri_query_params_object *new_uri_query_params_object = php_uri_rfc3986_uri_query_params_object_from_obj(
+		object->ce->create_object(object->ce)
+	);
+
+	new_uri_query_params_object->query_list = uri_query_params_object->query_list; // TODO Fix
+
+	zend_objects_clone_members(&new_uri_query_params_object->std, &uri_query_params_object->std);
+
+	return &new_uri_query_params_object->std;
+}
+
+ZEND_ATTRIBUTE_NONNULL zend_result php_uri_rfc3986_uri_query_params_from_str(const char *query_str_first,
+	size_t query_str_length, UriQueryListA **query_list, bool silent
+) {
+	int item_count;
+
+	if (uriDissectQueryMallocExMmA(
+		query_list, &item_count, query_str_first, query_str_first + query_str_length,
+		URI_TRUE, URI_BR_DONT_TOUCH, mm
+	) != URI_SUCCESS) {
+		if (!silent) {
+			zend_throw_exception(php_uri_ce_exception, "Failed to parse the specified query string", 0);
+		}
+
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+
+static UriQueryListA *php_uri_rfc3986_uri_query_params_search_last_item(UriQueryListA *query_list)
+{
+	if (query_list == NULL) {
+		return NULL;
+	}
+
+	UriQueryListA *p = query_list;
+
+	while (p->next != NULL) {
+		p = p->next;
+	}
+
+	return p;
+}
+
+ZEND_ATTRIBUTE_NONNULL_ARGS(2) UriQueryListA *php_uri_rfc3986_uri_query_params_search_first(UriQueryListA *query_list,
+	const char *name, size_t name_len, const char *value, size_t value_len
+) {
+	for (UriQueryListA *p = query_list; p != NULL; p = p->next) {
+		if (zend_binary_strcmp(name, name_len, p->key, strlen(p->key)) != 0) {
+			continue;
+		}
+
+		if (EXPECTED(value == NULL)) {
+			return p;
+		}
+
+		if (zend_binary_strcmp(value, value_len, p->value, strlen(p->value))) { // TODO check null values
+			return p;
+		}
+	}
+
+	return NULL;
+}
+
+ZEND_ATTRIBUTE_NONNULL_ARGS(1,2) zend_result php_uri_rfc3986_uri_query_params_append(UriQueryListA **query_list,
+	const char *name, size_t name_len, const char *value, size_t value_len
+) {
+	int item_count;
+
+	UriQueryListA **next_item;
+	UriQueryListA *last_item = php_uri_rfc3986_uri_query_params_search_last_item(*query_list);
+	if (UNEXPECTED(last_item == NULL)) {
+		UriQueryListA *tmp = emalloc(sizeof(*tmp));
+		tmp->key = NULL;
+		tmp->value = NULL;
+		tmp->next = NULL;
+
+		*query_list = tmp;
+		next_item = query_list;
+	} else {
+		next_item = &last_item->next;
+	}
+
+	bool result = uriAppendQueryItemA(next_item, &item_count,
+		name, name + name_len, value, value ? value + value_len : 0,
+		URI_TRUE, URI_BR_DONT_TOUCH, mm
+	);
+
+	return result == URI_TRUE ? SUCCESS : FAILURE;
+}
+
+zend_string *php_uri_rfc3986_uri_query_params_to_string(const UriQueryListA *query_list)
+{
+	if (query_list == NULL) {
+		return zend_empty_string;
+	}
+
+	int chars_required = 0;
+	if (uriComposeQueryCharsRequiredExA(query_list, &chars_required, true, URI_BR_DONT_TOUCH) != URI_SUCCESS) {
+		return NULL;
+	}
+
+	zend_string *query_string = zend_string_alloc(chars_required, false);
+	int chars_written;
+	if (uriComposeQueryExA(ZSTR_VAL(query_string), query_list, chars_required + 1, &chars_written, URI_TRUE, URI_FALSE) != URI_SUCCESS) {
+		zend_string_efree(query_string);
+		return NULL;
+	}
+
+	if (chars_written == chars_required) {
+		return query_string;
+	}
+
+	return zend_string_truncate(query_string, chars_written - 1, false);
+}
+
+ZEND_ATTRIBUTE_NONNULL HashTable *php_uri_rfc3986_uri_query_params_get_debug_properties(php_uri_parser_rfc3986_uri_query_params_object *object)
+{
+	const HashTable *std_properties = zend_std_get_properties(&object->std);
+	HashTable *result = zend_array_dup(std_properties);
+
+	for (UriQueryListA *param = object->query_list; param != NULL; param = param->next) {
+		zval tmp;
+
+		if (param->value == NULL) {
+			ZVAL_NULL(&tmp);
+		} else {
+			ZVAL_STRING(&tmp, param->value);
+		}
+
+		zend_hash_str_add_new(result, param->key, strlen(param->key), &tmp);
+	}
+
+	return result;
 }
 
 PHPAPI const php_uri_parser php_uri_parser_rfc3986 = {

--- a/ext/uri/uri_parser_rfc3986.h
+++ b/ext/uri/uri_parser_rfc3986.h
@@ -22,10 +22,53 @@
 PHPAPI extern const php_uri_parser php_uri_parser_rfc3986;
 
 typedef struct php_uri_parser_rfc3986_uris php_uri_parser_rfc3986_uris;
+typedef struct UriQueryListStructA UriQueryListA;
 
+typedef struct php_uri_parser_rfc3986_uri_query_params_object {
+	UriQueryListA *query_list;
+	bool is_initialized;
+	zend_object std;
+} php_uri_parser_rfc3986_uri_query_params_object;
+
+#define Z_URI_QUERY_PARAMS_OBJECT_P(zv) php_uri_rfc3986_uri_query_params_object_from_obj(Z_OBJ_P((zv)))
+
+static inline php_uri_parser_rfc3986_uri_query_params_object *php_uri_rfc3986_uri_query_params_object_from_obj(zend_object *object) {
+	return (php_uri_parser_rfc3986_uri_query_params_object*)((char*)(object) - XtOffsetOf(php_uri_parser_rfc3986_uri_query_params_object, std));
+}
+
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_user_info(const zend_string *str);
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_host(const zend_string *str);
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_path(const zend_string *str);
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_path_segment(const zend_string *str);
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_relative_reference_path(const zend_string *str);
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_relative_reference_first_path_segment(const zend_string *str);
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_query_or_fragment(const zend_string *str);
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_reserved_characters(const zend_string *str);
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_encode_all(const zend_string *str);
+
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_decode(const zend_string *str);
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_rfc3986_percent_decode_reserved_characters(const zend_string *str);
+
+ZEND_ATTRIBUTE_NONNULL void php_uri_parser_rfc3986_uri_type_read(void *uri, zval *retval);
 zend_result php_uri_parser_rfc3986_userinfo_read(php_uri_parser_rfc3986_uris *uri, php_uri_component_read_mode read_mode, zval *retval);
 zend_result php_uri_parser_rfc3986_userinfo_write(php_uri_parser_rfc3986_uris *uri, zval *value, zval *errors);
+void php_uri_parser_rfc3986_host_type_read(void *uri, php_uri_component_read_mode read_mode, zval *retval);
+zend_result php_uri_parser_rfc3986_path_segments_read(void *uri, php_uri_component_read_mode read_mode, zval *retval);
+zend_result php_uri_parser_rfc3986_path_segments_write(php_uri_parser_rfc3986_uris *uri, zval *value, bool include_leading_slash_for_non_empty_relative_uri);
+zend_result php_uri_parser_rfc3986_path_query_params_read(void *uri, php_uri_component_read_mode read_mode, zval *retval);
+ZEND_ATTRIBUTE_NONNULL zend_result php_uri_parser_rfc3986_query_params_read(void *uri, php_uri_component_read_mode read_mode, zval *retval);
+ZEND_ATTRIBUTE_NONNULL zend_result php_uri_parser_rfc3986_query_params_write(void *uri, zval *value);
 
 php_uri_parser_rfc3986_uris *php_uri_parser_rfc3986_parse_ex(const char *uri_str, size_t uri_str_len, const php_uri_parser_rfc3986_uris *uriparser_base_url, bool silent);
+
+PHPAPI void php_uri_rfc3986_uri_query_params_free(php_uri_parser_rfc3986_uri_query_params_object *uri_query_params_object);
+PHPAPI void php_uri_rfc3986_uri_query_params_object_handler_free(zend_object *object);
+zend_object *php_uri_rfc3986_uri_query_params_object_handler_clone(zend_object *object);
+zend_result php_uri_rfc3986_uri_query_params_from_str(const char *query_str_first, size_t query_str_length, UriQueryListA **query_list, bool silent);
+ZEND_ATTRIBUTE_NONNULL_ARGS(1,2) zend_result php_uri_rfc3986_uri_query_params_append(UriQueryListA **query_list,
+	const char *name, size_t name_len, const char *value, size_t value_len
+);
+zend_string *php_uri_rfc3986_uri_query_params_to_string(const UriQueryListA *query_list);
+HashTable *php_uri_rfc3986_uri_query_params_get_debug_properties(php_uri_parser_rfc3986_uri_query_params_object *object);
 
 #endif

--- a/ext/uri/uri_parser_whatwg.h
+++ b/ext/uri/uri_parser_whatwg.h
@@ -22,7 +22,52 @@
 
 PHPAPI extern const php_uri_parser php_uri_parser_whatwg;
 
+typedef struct php_uri_parser_whatwg_url_query_params_object {
+	lxb_url_search_params_t *query_params;
+	bool is_initialized;
+	zend_object std;
+} php_uri_parser_whatwg_url_query_params_object;
+
+#define Z_URL_QUERY_PARAMS_OBJECT_P(zv) php_uri_whatwg_url_query_params_object_from_obj(Z_OBJ_P((zv)))
+
+static inline php_uri_parser_whatwg_url_query_params_object *php_uri_whatwg_url_query_params_object_from_obj(zend_object *object) {
+	return (php_uri_parser_whatwg_url_query_params_object*)((char*)(object) - XtOffsetOf(php_uri_parser_whatwg_url_query_params_object, std));
+}
+
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_whatwg_percent_encode_user_info(const zend_string *str);
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_whatwg_percent_encode_host(const zend_string *str);
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_whatwg_percent_encode_opaque_host(const zend_string *str);
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_whatwg_percent_encode_path(const zend_string *str);
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_whatwg_percent_encode_path_segment(const zend_string *str);
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_whatwg_percent_encode_opaque_path(const zend_string *str);
+ZEND_ATTRIBUTE_NONNULL zend_string *php_uri_parser_whatwg_percent_encode_opaque_path_segment(const zend_string *str);
+
+ZEND_ATTRIBUTE_NONNULL  bool php_uri_parser_whatwg_is_special(lxb_url_t *lexbor_uri);
+ZEND_ATTRIBUTE_NONNULL void php_uri_parser_whatwg_host_type_read(void *uri, php_uri_component_read_mode read_mode, zval *retval);
+ZEND_ATTRIBUTE_NONNULL zend_result php_uri_parser_whatwg_path_segments_read(void *uri, php_uri_component_read_mode read_mode, zval *retval);
+ZEND_ATTRIBUTE_NONNULL zend_result php_uri_parser_whatwg_query_params_read(void *uri, php_uri_component_read_mode read_mode, zval *retval);
+ZEND_ATTRIBUTE_NONNULL zend_result php_uri_parser_whatwg_query_params_write(void *uri, zval *value, zval *errors);
+
 lxb_url_t *php_uri_parser_whatwg_parse_ex(const char *uri_str, size_t uri_str_len, const lxb_url_t *lexbor_base_url, zval *errors, bool silent);
+
+PHPAPI ZEND_ATTRIBUTE_NONNULL void php_uri_whatwg_url_query_params_free(php_uri_parser_whatwg_url_query_params_object *url_query_params_object);
+PHPAPI ZEND_ATTRIBUTE_NONNULL void php_uri_whatwg_url_query_params_object_handler_free(zend_object *object);
+ZEND_ATTRIBUTE_NONNULL zend_object *php_uri_whatwg_url_query_params_object_handler_clone(zend_object *object);
+ZEND_ATTRIBUTE_NONNULL lxb_url_search_params_t *php_uri_whatwg_url_query_params_from_str(const char *query_str, size_t query_str_len, bool silent);
+ZEND_ATTRIBUTE_NONNULL zend_result php_uri_whatwg_url_query_params_append(lxb_url_search_params_t *query_params,
+	const char *name, size_t name_len, const char *value, size_t value_len
+);
+ZEND_ATTRIBUTE_NONNULL_ARGS(1, 2) void php_uri_whatwg_url_query_params_delete(lxb_url_search_params_t *query_params,
+	const char *name, size_t name_len, const char *value, size_t value_len
+);
+ZEND_ATTRIBUTE_NONNULL_ARGS(1, 2) bool php_uri_whatwg_url_query_params_exists(lxb_url_search_params_t *query_params,
+	const char *name, size_t name_len, const char *value, size_t value_len
+);
+ZEND_ATTRIBUTE_NONNULL zend_string * php_uri_whatwg_url_query_params_get_first(lxb_url_search_params_t *query_params,
+	const char *name, size_t name_len
+);
+zend_string *php_uri_whatwg_url_query_params_to_string(lxb_url_search_params_t *query_list);
+HashTable *php_uri_whatwg_url_query_params_get_debug_properties(php_uri_parser_whatwg_url_query_params_object *object);
 
 PHP_RINIT_FUNCTION(uri_parser_whatwg);
 ZEND_MODULE_POST_ZEND_DEACTIVATE_D(uri_parser_whatwg);

--- a/ext/uri/uriparser/include/uriparser/Uri.h
+++ b/ext/uri/uriparser/include/uriparser/Uri.h
@@ -1120,6 +1120,16 @@ URI_PUBLIC void URI_FUNC(FreeQueryList)(URI_TYPE(QueryList) * queryList);
 URI_PUBLIC int URI_FUNC(FreeQueryListMm)(URI_TYPE(QueryList) * queryList,
                                          UriMemoryManager * memory);
 
+
+
+/* TODO custom modification */
+UriBool URI_FUNC(AppendQueryItem)(URI_TYPE(QueryList) ** prevNext,
+	int * itemCount, const URI_CHAR * keyFirst, const URI_CHAR * keyAfter,
+	const URI_CHAR * valueFirst, const URI_CHAR * valueAfter,
+	UriBool plusToSpace, UriBreakConversion breakConversion, UriMemoryManager * memory);
+
+
+
 /**
  * Makes the %URI hold copies of strings so that it no longer depends
  * on the original %URI string.  If the %URI is already owner of copies,

--- a/ext/uri/uriparser/src/UriQuery.c
+++ b/ext/uri/uriparser/src/UriQuery.c
@@ -74,7 +74,8 @@ static int URI_FUNC(ComposeQueryEngine)(URI_CHAR * dest,
                                         int * charsRequired, UriBool spaceToPlus,
                                         UriBool normalizeBreaks);
 
-static UriBool URI_FUNC(AppendQueryItem)(
+/* TODO Custom modification */
+UriBool URI_FUNC(AppendQueryItem)(
     URI_TYPE(QueryList) * *prevNext, int * itemCount, const URI_CHAR * keyFirst,
     const URI_CHAR * keyAfter, const URI_CHAR * valueFirst, const URI_CHAR * valueAfter,
     UriBool plusToSpace, UriBreakConversion breakConversion, UriMemoryManager * memory);


### PR DESCRIPTION
It has the following features following up the original URI RFC (https://wiki.php.net/rfc/url_parsing_api):

- URI builder
- Query string manipulation
- Retrieving/modifying path segments as an array
- Retrieving the host type (e.g. IPv4, IPV6, domain name etc.)
- Retrieving the RFC 3986 URI type (relative reference, URI etc.)
- Deciding if the WHATWG URL is special (whether it uses the HTTP, HTTPS, FTP etc. schemes)
- Dedicated support for percent-encoding/decoding

